### PR TITLE
Allow use of % in the message string.

### DIFF
--- a/lib/semantic_logger/appender/syslog.rb
+++ b/lib/semantic_logger/appender/syslog.rb
@@ -206,7 +206,9 @@ module SemanticLogger
 
         case @protocol
         when :syslog
-          ::Syslog.log @level_map[log.level], formatter.call(log)
+          # Since the Ruby Syslog API supports sprintf format strings, double up all existing '%'
+          message = formatter.call(log).gsub "%", "%%"
+          ::Syslog.log @level_map[log.level], message
         when :tcp
           @remote_syslog.retry_on_connection_failure { @remote_syslog.write("#{syslog_packet_formatter(log)}\r\n") }
         when :udp
@@ -247,7 +249,6 @@ module SemanticLogger
         packet.content = default_formatter.call(log)
         packet.to_s
       end
-
     end
   end
 end

--- a/test/appender_syslog_test.rb
+++ b/test/appender_syslog_test.rb
@@ -46,5 +46,14 @@ class AppenderSyslogTest < Test::Unit::TestCase
       end
     end
 
+    should "allow logging with %" do
+      message = "AppenderSyslogTest %test"
+      syslog_appender = SemanticLogger::Appender::Syslog.new
+
+      assert_nothing_raised ArgumentError do
+        syslog_appender.debug(message)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Syslog behaves like printf which causes an `ArgumentError` any time a % is seen in the printed log
