### PR TITLE
Add default index for Splunk appender

### DIFF
--- a/lib/semantic_logger/appender/splunk.rb
+++ b/lib/semantic_logger/appender/splunk.rb
@@ -46,7 +46,7 @@ class SemanticLogger::Appender::Splunk < SemanticLogger::Appender::Base
       password: options[:password]
     }
 
-    @index = options[:index]
+    @index = options[:index] || 'main'
 
     if @config[:username].nil?
       raise ArgumentError, 'Must supply a username.'

--- a/test/appender_splunk_test.rb
+++ b/test/appender_splunk_test.rb
@@ -22,30 +22,24 @@ class AppenderSplunkTest < Minitest::Test
 
           assert_equal 'Must supply a password.', error.message
         end
-
-        it 'raise argument error for missing index' do
-          error = assert_raises ArgumentError do
-            SemanticLogger::Appender::Splunk.new(username: 'username', password: 'password')
-          end
-
-          assert_equal 'Must supply an index.', error.message
-        end
       end
 
       describe 'set default values' do
         it 'have default values' do
           appender = Splunk.stub(:connect, Splunk::Service.new({})) do
             Splunk::Service.stub_any_instance(:indexes, {}) do
-              SemanticLogger::Appender::Splunk.new(username: 'username', password: 'password', index: 'index')
+              SemanticLogger::Appender::Splunk.new(username: 'username', password: 'password')
             end
           end
           config   = appender.config
           # Default host
           assert_equal 'localhost', config[:host]
-          # Default pot
+          # Default port
           assert_equal 8089, config[:port]
           # Default scheme
           assert_equal :https, config[:scheme]
+          #Default index
+          assert_equal 'main', appender.index
         end
       end
     end


### PR DESCRIPTION
Hello,
In order to ease development with this library, I've added a default for the `index` parameter in the Splunk appender. Since a default install of Splunk comes with the `main` index, this will just send the logs there by default.

I'm curious what you think. Let me know

Thanks