### PR TITLE
Add Logftm formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- adds Logfmt formatter
+
 ### Changed
 
 ### Fixed

--- a/lib/semantic_logger/formatters.rb
+++ b/lib/semantic_logger/formatters.rb
@@ -10,6 +10,7 @@ module SemanticLogger
     autoload :Signalfx,         "semantic_logger/formatters/signalfx"
     autoload :Syslog,           "semantic_logger/formatters/syslog"
     autoload :Fluentd,          "semantic_logger/formatters/fluentd"
+    autoload :Logfmt,            "semantic_logger/formatters/logfmt"
     # @formatter:on
 
     # Return formatter that responds to call.

--- a/lib/semantic_logger/formatters/logfmt.rb
+++ b/lib/semantic_logger/formatters/logfmt.rb
@@ -1,0 +1,54 @@
+require 'json'
+
+module SemanticLogger
+  module Formatters
+    class Logfmt < Raw
+      def initialize(time_format: :iso_8601, time_key: :timestamp, **args)
+        super(time_format: time_format, time_key: time_key, **args)
+      end
+
+      def call(log, logger)
+        @raw = super(log, logger)
+
+        raw_to_logfmt
+      end
+
+      private
+
+      def raw_to_logfmt
+        @parsed = @raw.slice(:timestamp, :level, :name, :message, :duration).merge tag: "success"
+        handle_payload
+        handle_exception
+
+        flatten_log
+      end
+
+      def handle_payload
+        return unless @raw.has_key? :payload
+
+        @parsed = @parsed.merge(@raw[:payload])
+      end
+
+      def handle_exception
+        return unless @raw.has_key? :exception
+
+        @parsed[:tag] = "exception"
+        @parsed = @parsed.merge(@raw[:exception])
+      end
+
+      def flatten_log
+        flattened = @parsed.map do |key, value|
+          "#{key}=#{parse_value(value)}"
+        end
+
+        flattened.join(' ')
+      end
+
+      def parse_value(value)
+        return value.to_json if value.instance_of? String
+
+        value
+      end
+    end
+  end
+end

--- a/test/formatters/logfmt_test.rb
+++ b/test/formatters/logfmt_test.rb
@@ -1,0 +1,71 @@
+require_relative "../test_helper"
+module SemanticLogger
+  module Formatters
+    class LogfmtTest < Minitest::Test
+      describe Logfmt do
+        let(:log_time) do
+          Time.utc(2020, 7, 20, 8, 32, 5.375276)
+        end
+      
+        let(:log) do
+          log = SemanticLogger::Log.new("DefaultTest", :info)
+          log.time = log_time
+          log
+        end
+      
+        let(:formatter) do
+          formatter = SemanticLogger::Formatters::Logfmt.new(log_host: false)
+          # Does not use the logger instance for formatting purposes
+          formatter.call(log, nil)
+          formatter
+        end
+      
+        let(:set_exception) do
+          raise "Oh no"
+        rescue StandardError => e
+          log.exception = e
+        end
+
+        describe "call" do
+          it "parses log to logfmt" do
+            assert_match formatter.call(log, nil), "timestamp=\"2020-07-20T08:32:05.375276Z\" level=info name=\"DefaultTest\" tag=\"success\""
+          end
+      
+          it "flattens payload information" do
+            log.payload = { shrek: "the ogre", controller: "some cotroller" }
+            assert_match /shrek=\"the ogre\" controller=\"some cotroller\"/, formatter.call(log, nil)
+          end
+      
+          it "changes name to payload information" do
+            log.payload = { name: "shrek" }
+            assert_match /name=\"shrek\"/, formatter.call(log, nil)
+          end
+      
+          describe "when no exception found" do
+            it "has tag success" do
+              assert_match  /tag="success"/, formatter.call(log, nil)
+            end
+          end
+      
+          describe "when exception ocurrs" do
+            it "has tag exception" do
+              set_exception
+              assert_match /tag=\"exception\"/, formatter.call(log, nil)
+            end
+      
+            it "flattens exception info" do
+              set_exception
+              assert_match /message=\"Oh no\"/, formatter.call(log, nil) 
+            end
+      
+            it "changes name to exception" do
+              log.payload = { name: "shrek" }
+              set_exception
+              assert_match  /name=\"RuntimeError\"/, formatter.call(log, nil)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Issue # (if available)

None

### Changelog

added :)

### Description of changes
In this pr:
- Add Logfmt formatter to be used. Logfmt is plenty used on the industry to easily parse and write logs. We are currently using this approach in production


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
