### PR TITLE
Logfmt support for ruby 2.3 and 2.4

### DIFF
--- a/lib/semantic_logger/formatters/logfmt.rb
+++ b/lib/semantic_logger/formatters/logfmt.rb
@@ -16,7 +16,10 @@ module SemanticLogger
       private
 
       def raw_to_logfmt
-        @parsed = @raw.slice(:timestamp, :level, :name, :message, :duration).merge tag: "success"
+        @parsed = @raw.select do |key, value|
+          [:timestamp, :level, :name, :message, :duration].include?(key)
+        end
+        @parsed = @parsed.merge tag: "success"
         handle_payload
         handle_exception
 

--- a/test/formatters/logfmt_test.rb
+++ b/test/formatters/logfmt_test.rb
@@ -21,9 +21,11 @@ module SemanticLogger
         end
       
         let(:set_exception) do
-          raise "Oh no"
-        rescue StandardError => e
-          log.exception = e
+          begin
+            raise "Oh no"
+          rescue StandardError => e
+            log.exception = e
+          end
         end
 
         describe "call" do


### PR DESCRIPTION
### Issue # (if available)

Latest PR didn't pass ruby 2.3 and 2.4, my bad using a newer version.

### Changelog

No need, would really appreciate a release so we can use rails-semantic-logger with it

### Description of changes

Changes rescue to `begin` `rescue` `end` format

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
