### PR TITLE
Fix changelog typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Dropped support for Ruby 2.4 and 2.5.
+- Dropped support for Ruby 2.3 and 2.4.
 - Moved testing to Github Actions.
 
 ### Fixed


### PR DESCRIPTION
The dropped support was for 2.3 not for 2.5... looks like a typo

### Issue # (if available)

### Changelog

Pull requests will not be accepted without a description of this change under the `[unreleased]` section 
in the file `CHANGELOG`.

### Description of changes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
