### PR TITLE
Silence method redifinition warnings whe Rails is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fixed method redifinition warnings when Rails is also used
+
 ## [4.8.1]
 
 - Fixed issue where adding a file appender was being ignored after a console appender had already been added.

--- a/lib/semantic_logger/loggable.rb
+++ b/lib/semantic_logger/loggable.rb
@@ -32,7 +32,14 @@ module SemanticLogger
   module Loggable
     def self.included(base)
       base.extend ClassMethods
+      base.singleton_class.class_eval do
+        undef_method :logger if method_defined?(:logger)
+        undef_method :logger= if method_defined?(:logger=)
+      end
       base.class_eval do
+        undef_method :logger if method_defined?(:logger)
+        undef_method :logger= if method_defined?(:logger=)
+
         # Returns [SemanticLogger::Logger] class level logger
         def self.logger
           @semantic_logger ||= SemanticLogger[self]


### PR DESCRIPTION
```
$ RUBYOPT='-w' bundle exec rspec
…   
…/semantic_logger-4.8.1/lib/semantic_logger/loggable.rb:37: warning: method redefined; discarding old logger
…/activerecord-6.1.4/lib/active_record/core.rb:20: warning: previous definition of logger was here
…/semantic_logger-4.8.1/lib/semantic_logger/loggable.rb:42: warning: method redefined; discarding old logger=
…/activerecord-6.1.4/lib/active_record/core.rb:20: warning: previous definition of logger= was here
…/semantic_logger-4.8.1/lib/semantic_logger/loggable.rb:47: warning: method redefined; discarding old logger
…/activerecord-6.1.4/lib/active_record/core.rb:20: warning: previous definition of logger was here
…/semantic_logger-4.8.1/lib/semantic_logger/loggable.rb:37: warning: method redefined; discarding old logger
…/actionview-6.1.4/lib/action_view/base.rb:169: warning: previous definition of logger was here
…/semantic_logger-4.8.1/lib/semantic_logger/loggable.rb:52: warning: method redefined; discarding old logger=
…
```

### Description of changes
Warnings bad, no warnings good.
Unfortunately can't add this check to CI since many tested deps has warning. It's possible to add [warnings gem](https://github.com/jeremyevans/ruby-warning) to devdeps and check specifically for rails deps, not sure if I should do it though.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
