### PR TITLE
Fix inconsistencies in timezone handling for elasticsearch appender

### DIFF
--- a/lib/semantic_logger/formatters/base.rb
+++ b/lib/semantic_logger/formatters/base.rb
@@ -70,6 +70,7 @@ module SemanticLogger
 
       # Return the Time as a formatted string
       def format_time(time)
+        time = time.dup
         case time_format
         when :rfc_3339
           time.utc.to_datetime.rfc3339

--- a/test/appender/elasticsearch_http_test.rb
+++ b/test/appender/elasticsearch_http_test.rb
@@ -20,7 +20,7 @@ module Appender
         @appender.stub(:post, ->(_json, ind) { index = ind }) do
           @appender.info @message
         end
-        assert_equal "/semantic_logger-#{Time.now.utc.strftime('%Y.%m.%d')}/log", index
+        assert_equal "/semantic_logger-#{Time.now.strftime('%Y.%m.%d')}/log", index
       end
 
       SemanticLogger::LEVELS.each do |level|


### PR DESCRIPTION
### Issue #176

### Changelog

I'm actually not sure how to put it in the changelog.

### Description of changes

This was actually not a problem with tests, but actual bug in the implementation of elasticsearch appender. This was due to the fact that `Time#utc` method, used in raw formatter, which is in turn used by ES appender, mutates the `Time` object in-place. See:

```
irb(main):001:0* t = Time.now
=> 2021-10-13 01:25:20.920377865 +0200
irb(main):002:0> t.utc
=> 2021-10-12 23:25:20.920377865 UTC
irb(main):003:0> t
=> 2021-10-12 23:25:20.920377865 UTC
```

The fix is to force the formatter to operate on a duplicate of the `Time` object, so actual time in log entry is not mutated.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
