### PR TITLE
[docs] Link to GitHub Actions CI config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Documentation: Fix link to GitHub Actions CI configuration.
+
 ## [5.0.0]
 
 - Separate out File and IO log appenders.

--- a/docs/index.md
+++ b/docs/index.md
@@ -222,6 +222,6 @@ Output:
 ### Ruby Support
 
 For the complete list of supported Ruby versions, see
-the [Testing file](https://github.com/reidmorrison/semantic_logger/blob/master/.travis.yml).
+the [Testing file](https://github.com/reidmorrison/semantic_logger/blob/master/.github/workflows/ci.yml).
 
 ### [Next: Rails ==>](rails.html)

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -11,7 +11,7 @@ for every Controller-Action call.
 ### Rails Support
 
 For the complete list of supported Ruby and Rails versions, see
-the [Testing file](https://github.com/reidmorrison/rails_semantic_logger/blob/master/.travis.yml).
+the [Testing file](https://github.com/reidmorrison/semantic_logger/blob/master/.github/workflows/ci.yml).
 
 ### Installation
 


### PR DESCRIPTION


### Description of changes

This replaces the Travis CI configuration, now a 404.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
