### PR TITLE
Unpack array of tags in `tagged` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Documentation: Fix link to GitHub Actions CI configuration.
+- Handle case when tags are passed as an array in a single argument to `SemanticLogger::Base#tagged`.
 
 ## [5.0.0]
 
 - Separate out File and IO log appenders.
 - Add "log rotation" like capabilities to the File appender.
-  - Re-open the log file after a specified number of log entries. 
+  - Re-open the log file after a specified number of log entries.
     - See new SemanticLogger::Appender::File option `reopen_count`.
-  - Re-open the log file after a specified number of bytes have been written by this process. 
+  - Re-open the log file after a specified number of bytes have been written by this process.
     - See new SemanticLogger::Appender::File option `reopen_size`.
   - New format directives so that file name dynamically includes any of the following attributes
     every time the log file is re-opened:
@@ -67,7 +68,7 @@ Note: See the readme for v5 upgrade instructions.
 
 - Remove `host` from the `SplunkHttp` appender message body.
 - Support Bugsnag 6. Fix infinite loop. #150
-- Fix documentation. #158 
+- Fix documentation. #158
 
 ## [4.7.2]
 

--- a/lib/semantic_logger/base.rb
+++ b/lib/semantic_logger/base.rb
@@ -188,7 +188,8 @@ module SemanticLogger
     # - For better performance with clean tags, see `SemanticLogger.tagged`.
     def tagged(*tags, &block)
       # Allow named tags to be passed into the logger
-      if tags.size == 1
+      # Rails::Rack::Logger passes logs as an array with a single argument
+      if tags.size == 1 && !tags.first.is_a?(Array)
         tag = tags[0]
         return yield if tag.nil? || tag == ""
 

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -384,6 +384,16 @@ class LoggerTest < Minitest::Test
           assert_equal %w[12345 DJHSFK], log.tags
         end
       end
+
+      it "properly handles logs as an array with a single argument" do
+        logger.tagged(%w[first second]) do
+          logger.info("hello world")
+
+          assert log = log_message
+          assert_equal "hello world", log.message
+          assert_equal %w[first second], log.tags
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Description of changes

[Rails::Rack::Logger](https://github.com/rails/rails/blob/main/railties/lib/rails/rack/logger.rb) and [RailsSemanticLogger::Rack::Logger](https://github.com/reidmorrison/rails_semantic_logger/blob/master/lib/rails_semantic_logger/rack/logger.rb) can pass tags as an array in a single argument to `SemanticLogger::Base#tagged`. `SemanticLogger` casts this array to string. I fixed this behavior: unpack tags instead of casting to string.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
