### PR TITLE
Enforce UTF-8 encoding for HTTP appenders

### DIFF
--- a/lib/semantic_logger/appender/http.rb
+++ b/lib/semantic_logger/appender/http.rb
@@ -162,6 +162,7 @@ module SemanticLogger
 
       # Forward log messages to HTTP Server
       def log(log)
+        log = log.encode('UTF-8', invalid: :replace, undef: :replace replace: '<replaced-during-utf-8-conversion>')
         message = formatter.call(log, self)
         logger.trace(message)
         post(message)


### PR DESCRIPTION
### Issue #180 

### Description of changes

Force UTF-8 encoding for all HTTP appenders.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
