### PR TITLE
Add support for elastic data-streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Documentation: Fix link to GitHub Actions CI configuration.
+- Add support for logging to elastic data-streams
 
 ## [5.0.0]
 

--- a/docs/appenders.md
+++ b/docs/appenders.md
@@ -277,8 +277,10 @@ Example:
 
 ~~~ruby
 SemanticLogger.add_appender(
-  appender: :elasticsearch,
-  url:      'http://localhost:9200'
+  appender:    :elasticsearch,
+  url:         'http://localhost:9200',
+  index:       'my-index',
+  data_stream: true
 )
 ~~~
 

--- a/lib/semantic_logger/appender/elasticsearch.rb
+++ b/lib/semantic_logger/appender/elasticsearch.rb
@@ -135,7 +135,7 @@ module SemanticLogger
                      application: nil,
                      environment: nil,
                      host: nil,
-                     metrics: false,
+                     data_stream: false,
                      **elasticsearch_args,
                      &block)
 
@@ -146,6 +146,7 @@ module SemanticLogger
         @elasticsearch_args          = elasticsearch_args.dup
         @elasticsearch_args[:url]    = url if url && !elasticsearch_args[:hosts]
         @elasticsearch_args[:logger] = logger
+        @data_stream = data_stream
 
         super(level: level, formatter: formatter, filter: filter, application: application, environment: environment, host: host, metrics: false, &block)
         reopen
@@ -175,7 +176,12 @@ module SemanticLogger
       private
 
       def write_to_elasticsearch(messages)
-        bulk_result = @client.bulk(body: messages)
+        bulk_result = if @data_stream
+                        @client.bulk(index: index, body: messages)
+                      else
+                        @client.bulk(body: messages)
+                      end
+
         return unless bulk_result["errors"]
 
         failed = bulk_result["items"].reject { |x| x["status"] == 201 }
@@ -184,11 +190,21 @@ module SemanticLogger
 
       def bulk_index(log)
         expanded_index_name = log.time.strftime("#{index}-#{date_pattern}")
-        {"index" => {"_index" => expanded_index_name, "_type" => type}}
+        if @data_stream
+          {"create" => {}}
+        else
+          {"index" => {"_index" => expanded_index_name, "_type" => type}}
+        end
       end
 
       def default_formatter
-        SemanticLogger::Formatters::Raw.new(time_format: :iso_8601, time_key: :timestamp)
+        time_key = if @data_stream
+                     "@timestamp"
+                   else
+                     :timestamp
+                   end
+
+        SemanticLogger::Formatters::Raw.new(time_format: :iso_8601, time_key: time_key)
       end
     end
   end

--- a/test/appender/elasticsearch_test.rb
+++ b/test/appender/elasticsearch_test.rb
@@ -39,6 +39,10 @@ module Appender
           appender.close
         end
 
+        it 'uses :timestamp as time_key' do
+          assert_equal :timestamp, appender.formatter.time_key
+        end
+
         describe "synchronous" do
           it "logs to daily indexes" do
             bulk_index = nil
@@ -79,6 +83,7 @@ module Appender
             log.payload = h
             request     = stub_client { appender.log(log) }
 
+            assert_nil = request[:index]
             assert hash = request[:body][1]
             refute hash[:stack_trace]
             assert_equal h, hash[:payload], hash
@@ -114,6 +119,94 @@ module Appender
             assert_equal index, body[2]["index"]["_index"]
             assert_equal "hello world2", body[3][:message]
             assert_equal index, body[4]["index"]["_index"]
+            assert_equal "hello world3", body[5][:message]
+          end
+        end
+
+        def stub_client(&block)
+          request = nil
+          appender.client.stub(:bulk, ->(r) { request = r; {"status" => 201} }, &block)
+          request
+        end
+      end
+
+      describe "logging to data-streams" do
+        let :appender do
+          if ENV["ELASTICSEARCH"]
+            SemanticLogger::Appender::Elasticsearch.new(
+              url: "http://localhost:9200",
+              data_stream: true
+            )
+          else
+            Elasticsearch::Transport::Client.stub_any_instance(:bulk, true) do
+              SemanticLogger::Appender::Elasticsearch.new(
+                url: "http://localhost:9200",
+                data_stream: true
+              )
+            end
+          end
+        end
+
+        let :log_message do
+          "AppenderElasticsearchTest log message"
+        end
+
+        let :log do
+          log         = SemanticLogger::Log.new("User", :info)
+          log.message = log_message
+          log
+        end
+
+        after do
+          appender.close
+        end
+
+        it 'uses @timestamp as time_key' do
+          assert_equal '@timestamp', appender.formatter.time_key
+        end
+
+        describe "synchronous" do
+          it "logs to data-stream index without date" do
+            request = stub_client { appender.log(log) }
+
+            assert_equal 'semantic_logger', request[:index]
+            assert hash = request[:body][1]
+            assert_equal log_message, hash[:message]
+          end
+        end
+
+        describe "async batch" do
+          it "logs message" do
+            request = stub_client { appender.batch([log]) }
+
+            assert body = request[:body]
+
+            assert_equal({}, body[0]["create"])
+            assert hash = body[1]
+            assert_equal log_message, hash[:message]
+            assert_equal :info, hash[:level]
+          end
+
+          let :logs do
+            Array.new(3) do |i|
+              l         = log.dup
+              l.message = "hello world#{i + 1}"
+              l
+            end
+          end
+
+          it "logs multiple messages" do
+            request = stub_client { appender.batch(logs) }
+
+            assert_equal 'semantic_logger', request[:index]
+            assert body = request[:body]
+            assert_equal 6, body.size, body
+
+            assert_equal({}, body[0]["create"])
+            assert_equal "hello world1", body[1][:message]
+            assert_equal({}, body[2]["create"])
+            assert_equal "hello world2", body[3][:message]
+            assert_equal({}, body[4]["create"])
             assert_equal "hello world3", body[5][:message]
           end
         end


### PR DESCRIPTION
### Issue #163

Support for elastic data-streams, see: https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html

### Changelog

### Description of changes

Data streams are slightly different to regular indexes:

1. They only support `create` operations, so we change the `index` operation to `create` operation, i.e.

    from this:
    ```
    PUT _bulk
    {"index": {"_index" => "index-name", "_type": "doc"}}
    { "timestamp": "2099-05-06T16:21:15.000Z", "message": "192.0.2.42 - - [06/May/2099:16:21:15 +0000] \"GET /images/bg.jpg HTTP/1.0\" 200 24736" }
    ```
    to this:
    ```
    PUT my-data-stream/_bulk
    { "create":{ } }
    { "@timestamp": "2099-05-06T16:21:15.000Z", "message": "192.0.2.42 - - [06/May/2099:16:21:15 +0000] \"GET /images/bg.jpg HTTP/1.0\" 200 24736" }
    ```
    When we remove the `index` operation, we still need to tell the API the name of the data stream, so we use the `index:` property of the `bulk` method.

2. data-streams expect a field called `@timestamp` so we set the `time_key` accordingly
3. add an appender option `data_stream: true/false` to enable/disable support for data-streams.

This should fix #163 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
