### PR TITLE
feat: Add tags to logfmt formatter output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Documentation: Fix link to GitHub Actions CI configuration.
+- feat: Add tags to logfmt formatter output
 
 ## [5.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Documentation: Fix link to GitHub Actions CI configuration.
 - feat: Add tags to logfmt formatter output
+- fix: Ensure time_key is used in logfmt formatter
 
 ## [5.0.0]
 

--- a/docs/log_struct.md
+++ b/docs/log_struct.md
@@ -18,6 +18,7 @@ Log = Struct.new(
   :time,
   :duration,
   :tags,
+  :named_tags,
   :level_index,
   :exception,
   :metric)
@@ -55,6 +56,10 @@ duration [Float]
 tags [Array<String>]
 
 * Any tags active on the thread when the log call was made
+
+named_tags [Hash<String, Object>]
+
+* Any named tags active on the thread when the log call was made
 
 level_index [Integer]
 

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -113,7 +113,7 @@ config.rails_semantic_logger.rendered   = true
 ![Semantic Disabled](images/rails_semantic_false.png)
 
 #### Include the file name and line number in the source code where the message originated
-**Warning:** Either set this to `nil` (to disable it completely) or to a high log level (`:fatal` or `:error`) in your production environment otherwise you risk encountering a memory leak due to the very high number of 
+**Warning:** Either set this to `nil` (to disable it completely) or to a high log level (`:fatal` or `:error`) in your production environment otherwise you risk encountering a memory leak due to the very high number of
 objects allocated when Ruby backtraces are created. This is best used in development for debugging purposes.
 
 ~~~ruby
@@ -317,6 +317,8 @@ Valid options:
     * Plain text output with color.
 * :json
     * JSON output format.
+* :logfmt
+    * logfmt output format.
 * :one_line
     * Reduce each log message to a single line.
 * `Object`

--- a/lib/semantic_logger/formatters/logfmt.rb
+++ b/lib/semantic_logger/formatters/logfmt.rb
@@ -2,6 +2,21 @@ require "json"
 
 module SemanticLogger
   module Formatters
+    # Produces logfmt formatted messages
+    #
+    # The following fields are extracted from the raw log and included in the formatted message:
+    #   :timestamp, :level, :name, :message, :duration, :tags, :named_tags
+    #
+    # E.g.
+    #   timestamp="2020-07-20T08:32:05.375276Z" level=info name="DefaultTest" base="breakfast" spaces="second breakfast" double_quotes="\"elevensies\"" single_quotes="'lunch'" tag="success"
+    #
+    # All timestamps are ISO8601 formatteed
+    # All user supplied values are escaped and surrounded by double quotes to avoid ambiguious message delimeters
+    # `tags` are flattened into a single comma separated key value pair. Avoid using commas in tags.
+    # `named_tags` are flattened are merged into the top level message field. Any conflicting fields are overridden.
+    # `payload` values take precedence over `tags` and `named_tags`. Any conflicting fields are overridden.
+    #
+    # Futher Reading https://brandur.org/logfmt
     class Logfmt < Raw
       def initialize(time_format: :iso_8601, time_key: :timestamp, **args)
         super(time_format: time_format, time_key: time_key, **args)
@@ -16,7 +31,7 @@ module SemanticLogger
       private
 
       def raw_to_logfmt
-        @parsed = @raw.slice(:timestamp, :level, :name, :message, :duration).merge tag: "success"
+        @parsed = @raw.slice(:timestamp, :level, :name, :message, :duration, :tags).merge(@raw.fetch(:named_tags){ {} }).merge(tag: "success")
         handle_payload
         handle_exception
 
@@ -45,9 +60,14 @@ module SemanticLogger
       end
 
       def parse_value(value)
-        return value.to_json if value.instance_of? String
-
-        value
+        case value
+        when Array
+          %Q|"#{value.join(",")}"|
+        when String
+          value.to_json
+        else
+          value
+        end
       end
     end
   end

--- a/lib/semantic_logger/formatters/logfmt.rb
+++ b/lib/semantic_logger/formatters/logfmt.rb
@@ -12,7 +12,7 @@ module SemanticLogger
     #
     # All timestamps are ISO8601 formatteed
     # All user supplied values are escaped and surrounded by double quotes to avoid ambiguious message delimeters
-    # `tags` are flattened into a single comma separated key value pair. Avoid using commas in tags.
+    # `tags` are treated as keys with boolean values. Tag names are not formatted or validated, ensure you use valid logfmt format for tag names.
     # `named_tags` are flattened are merged into the top level message field. Any conflicting fields are overridden.
     # `payload` values take precedence over `tags` and `named_tags`. Any conflicting fields are overridden.
     #

--- a/lib/semantic_logger/formatters/logfmt.rb
+++ b/lib/semantic_logger/formatters/logfmt.rb
@@ -31,7 +31,7 @@ module SemanticLogger
       private
 
       def raw_to_logfmt
-        @parsed = @raw.slice(:timestamp, :level, :name, :message, :duration, :tags).merge(@raw.fetch(:named_tags){ {} }).merge(tag: "success")
+        @parsed = @raw.slice(time_key, :level, :name, :message, :duration, :tags).merge(@raw.fetch(:named_tags){ {} }).merge(tag: "success")
         handle_payload
         handle_exception
 

--- a/lib/semantic_logger/semantic_logger.rb
+++ b/lib/semantic_logger/semantic_logger.rb
@@ -122,7 +122,7 @@ module SemanticLogger
   #     Default: SemanticLogger.default_level
   #
   #   formatter: [Symbol|Object|Proc]
-  #     Any of the following symbol values: :default, :color, :json
+  #     Any of the following symbol values: :default, :color, :json, :logfmt, etc...
   #       Or,
   #     An instance of a class that implements #call
   #       Or,

--- a/test/formatters/logfmt_test.rb
+++ b/test/formatters/logfmt_test.rb
@@ -16,7 +16,7 @@ module SemanticLogger
         end
 
         let(:formatter) do
-          formatter = SemanticLogger::Formatters::Logfmt.new(log_host: false)
+          formatter = SemanticLogger::Formatters::Logfmt.new(log_host: false, time_key: time_key)
           # Does not use the logger instance for formatting purposes
           formatter.call(log, nil)
           formatter
@@ -34,6 +34,10 @@ module SemanticLogger
 
         let(:named_tags) do
           {}
+        end
+
+        let(:time_key) do
+          :timestamp
         end
 
         describe "call" do
@@ -127,6 +131,18 @@ module SemanticLogger
                 assert_match(/double_quotes="\\"elevensies\\""/, text)
                 assert_match(/single_quotes="\'lunch\'"/, text)
               end
+            end
+          end
+
+          describe "given an time_key" do
+            let(:time_key) do
+              :ts
+            end
+
+            it "overrides the timestamp" do
+              text = formatter.call(log, nil)
+              refute_match(/timestamp=/, text)
+              assert_match(/ts=\"2020-07-20T08:32:05.375276Z\"/, text)
             end
           end
         end

--- a/test/formatters/logfmt_test.rb
+++ b/test/formatters/logfmt_test.rb
@@ -81,16 +81,13 @@ module SemanticLogger
 
           describe "given a set of tags" do
             let(:tags) do
-              ["breakfast", "second breakfast", %q{"elevensies"}, "'lunch'"]
+              ["ruby", "rails"]
             end
 
-            # This results in invalid logfmt keys
             it "formats the tag as a 'true' value" do
               text = formatter.call(log, nil)
-              assert_match(/breakfast=true/, text)
-              assert_match(/second breakfast=true/, text)
-              assert_match(/\"elevensies\"=true/, text)
-              assert_match(/'lunch'=true/, text)
+              assert_match(/ruby=true/, text)
+              assert_match(/rails=true/, text)
             end
 
             describe "given a payload with tags key" do
@@ -98,12 +95,23 @@ module SemanticLogger
                 log.payload = {tags: "apples,bananas,pears"}
 
                 text = formatter.call(log, nil)
-                assert_match(/breakfast=true/, text)
-                assert_match(/second breakfast=true/, text)
-                assert_match(/\"elevensies\"=true/, text)
-                assert_match(/'lunch'=true/, text)
+                assert_match(/ruby=true/, text)
+                assert_match(/rails=true/, text)
                 assert_match(/tags="apples,bananas,pears"/, text)
               end
+            end
+          end
+
+          describe "given a invalid tag names" do
+            let(:tags) do
+              ["second breakfast", %q{"elevensies"}, "'lunch'"]
+            end
+
+            it "formats the tag as a 'true' value" do
+              text = formatter.call(log, nil)
+              assert_match(/second breakfast=true/, text)
+              assert_match(/\"elevensies\"=true/, text)
+              assert_match(/'lunch'=true/, text)
             end
           end
 


### PR DESCRIPTION
### Issue # (if available)

Fixes https://github.com/reidmorrison/semantic_logger/issues/183

### Changelog

Pull requests will not be accepted without a description of this change under the `[unreleased]` section 
in the file `CHANGELOG`.

### Description of changes

Includes `tags` and `named_tags` in logfmt formatted messages. 

```ruby
# `tags` are treated as keys with boolean values. Tag names are not formatted or validated, ensure you use valid logfmt format for tag names.
# `named_tags` are flattened are merged into the top level message field. Any conflicting fields are overridden.
# `payload` values take precedence over `tags` and `named_tags`. Any conflicting fields are overridden.
```

This also fixes an issue were the provided `time_key` was not used in the formatted log record. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
