### PR TITLE
Fix `flush` on `AsyncBatch` appender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fixed `flush` on `AsyncBatch` appender not immediately writing logs
+
 ## [4.9.0]
 
 - Separate out File and IO log appenders.

--- a/lib/semantic_logger/appender/async_batch.rb
+++ b/lib/semantic_logger/appender/async_batch.rb
@@ -64,6 +64,7 @@ module SemanticLogger
           signal.wait(batch_seconds)
 
           logs          = []
+          messages      = []
           first         = true
           message_count = queue.length
           message_count.times do
@@ -76,10 +77,11 @@ module SemanticLogger
                 first = false
               end
             else
-              process_message(message)
+              messages << message
             end
           end
           appender.batch(logs) if logs.size.positive?
+          messages.each { |message| process_message(message) }
           signal.reset unless queue.size >= batch_size
         end
       end


### PR DESCRIPTION
When `flush` is called on a `AsyncBatch` appender `batch` is called
after `process_message` has finished (which handles the `flush` call).
This means that when `flush` returns the log messages are not actually
written yet and if the process exits at this point the logs are lost.

This was observed to lose log messages in an AWS Lambda environment.

