### PR TITLE
Yield logger to SemanticLogger::Logger#tagged for compatibility with ActiveSupport::TaggedLogging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Yield the logger instance to `SemanticLogger.tagged` for compatibility with ActiveSupport::TaggedLogging
+
 ## [4.10.0]
 
 - New Feature: Add support for newer `sentry-ruby` gem.

--- a/lib/semantic_logger/semantic_logger.rb
+++ b/lib/semantic_logger/semantic_logger.rb
@@ -10,6 +10,22 @@ module SemanticLogger
     Logger.new(klass)
   end
 
+  def self.default_logger
+    @default_logger ||= Logger.new(self)
+  end
+
+  def self.current_logger
+    @current_logger || default_logger
+  end
+
+  def self.with_current_logger(logger)
+    current_logger = Thread.current[:semantic_logger_current_logger] || default_logger
+    Thread.current[:semantic_logger_current_logger] = logger
+    yield
+  ensure
+    Thread.current[:semantic_logger_current_logger] = current_logger
+  end
+
   # Sets the global default log level
   def self.default_level=(level)
     @default_level = level
@@ -311,12 +327,12 @@ module SemanticLogger
   # If the tag being supplied is definitely a string then this fast
   # tag api can be used for short lived tags
   def self.fast_tag(tag)
-    return yield if tag.nil? || tag == ""
+    return yield(Thread.current[:semantic_logger_current_logger]) if tag.nil? || tag == ""
 
     t = Thread.current[:semantic_logger_tags] ||= []
     begin
       t << tag
-      yield
+      yield(Thread.current[:semantic_logger_current_logger])
     ensure
       t.pop
     end
@@ -343,7 +359,7 @@ module SemanticLogger
   #   to the equivalent of:
   #     `logger.tagged('first', 'more', 'other')`
   def self.tagged(*tags, &block)
-    return yield if tags.empty?
+    return yield(Thread.current[:semantic_logger_current_logger]) if tags.empty?
 
     # Allow named tags to be passed into the logger
     if tags.size == 1
@@ -353,7 +369,7 @@ module SemanticLogger
 
     begin
       push_tags(*tags)
-      yield
+      yield(Thread.current[:semantic_logger_current_logger])
     ensure
       pop_tags(tags.size)
     end
@@ -387,12 +403,12 @@ module SemanticLogger
 
   # :nodoc
   def self.named_tagged(hash)
-    return yield if hash.nil? || hash.empty?
+    return yield(Thread.current[:semantic_logger_current_logger]) if hash.nil? || hash.empty?
     raise(ArgumentError, "#named_tagged only accepts named parameters (Hash)") unless hash.is_a?(Hash)
 
     begin
       push_named_tags(hash)
-      yield
+      yield(Thread.current[:semantic_logger_current_logger])
     ensure
       pop_named_tags
     end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -394,6 +394,31 @@ class LoggerTest < Minitest::Test
           assert_equal %w[first second], log.tags
         end
       end
+
+      it "yields the logger" do
+        logger.tagged(foo: "bar") do |l|
+          l.info("hello world")
+        end
+
+        assert log = log_message
+        assert_equal "hello world", log.message
+        assert_equal({foo: "bar"}, log.named_tags)
+      end
+
+      it "yields the logger in another thread" do
+        t = Thread.new do
+          logger.tagged(thread: "new") do |l|
+            l.info("hello from the other thread")
+            assert_equal l, logger
+          end
+        end
+
+        t.join
+
+        assert log = log_message
+        assert_equal "hello from the other thread", log.message
+        assert_equal({thread: "new"}, log.named_tags)
+      end
     end
   end
 end

--- a/test/semantic_logger_test.rb
+++ b/test/semantic_logger_test.rb
@@ -33,6 +33,15 @@ class SemanticLoggerTest < Minitest::Test
           end
         end
 
+        it "add tags to log entries taking a block argument" do
+          SemanticLogger.tagged("12345", "DJHSFK") do |l|
+            l.info("Hello world")
+
+            assert log = log_message
+            assert_equal %w[12345 DJHSFK], log.tags
+          end
+        end
+
         it "add embedded tags to log entries" do
           SemanticLogger.tagged("First Level", "tags") do
             SemanticLogger.tagged("Second Level") do


### PR DESCRIPTION
### Description of changes

I am attempting to migrate a large codebase to use SemanticLogger. Previously we used `ActiveSupport::TaggedLogging`. 

It _mostly_ works as a drop-in replacement, but the signature of `logger.tagged` is different. We have a lot of places where we use:

```ruby
Rails.logger.tagged(something) do |logger|
  logger.info("this log statement will be tagged")
end
```

Due to the very large volume of this pattern, this has become a showstopper for moving to `semantic_logger`, despite all the benefits, like named tags, json formatter, multiple appenders, etc.

This change uses a thread variable to keep track of the "current" logger and yields it to the block so that it's compatible with the ActiveSupport tagged logging signature. I used a thread variable in order to avoid modifying the signature of any existing methods, since they have so many different ways they can be called, e.g:

```ruby
SemanticLogger.tagged("one", "two")
SemanticLogger.tagged(one: "one", two: "two")
SemanticLogger.tagged({one: "one", two: "two"})
# etc
```
...which makes it difficult or impossible to add a new param to that method without breaking something.

The tests are passing and I added one test for this use case. Please let me know if there's anything else you would like to see here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
