### PR TITLE
fix: log message from supplied message argument when payload contains payload key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - Updated RuboCop's target version to Ruby 2.7.5.
     - Updated minimum Ruby version to 2.7.5 as earlier versions are
       end-of-life.
+- Fixes #216 Log message from supplied message argument when payload contains payload key
 
 ## [4.11.0]
 

--- a/lib/semantic_logger/log.rb
+++ b/lib/semantic_logger/log.rb
@@ -144,7 +144,9 @@ module SemanticLogger
       raise(ArgumentError, "payload must be a Hash") unless payload.is_a?(Hash)
 
       message = nil if message == ""
-      return payload if payload.key?(:payload)
+      if payload.key?(:payload)
+        return payload.merge({ message: message }.compact)
+      end
 
       new_payload = {}
       args        = {}

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -117,6 +117,25 @@ class LoggerTest < Minitest::Test
             assert_equal payload, log.payload
           end
 
+          it "logs payload and message with payload keyword when the payload contains the message key" do
+            logger.send(level, "hello world", **{payload: payload})
+
+            assert log = log_message
+            assert_equal "hello world", log.message
+            assert_equal payload, log.payload
+          end
+
+          it "logs payload and message with payload keyword when the payload does not contain the message key" do
+            payload_without_message = payload.dup
+            payload_without_message.delete(:message)
+
+            logger.send(level, "hello world", **{payload: payload_without_message})
+
+            assert log = log_message
+            assert_equal "hello world", log.message
+            assert_equal payload_without_message, log.payload
+          end
+
           it "logs message without modifying the supplied hash" do
             details = { message: "hello world" }
             logger.send(level, details)


### PR DESCRIPTION
### Issue # (if available)

https://github.com/reidmorrison/semantic_logger/issues/216

### Changelog

Updated

### Description of changes

Support logging message in the format `logger.info("message", payload: { foo: "bar" })`, which stopped working in 4.11.0 due to the change in https://github.com/reidmorrison/semantic_logger/commit/90c6fa6f7905cb738011d001fd5d85ea56916e63

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
