### PR TITLE
Add missing autoload for syslog_cee formatter

### DIFF
--- a/lib/semantic_logger/formatters.rb
+++ b/lib/semantic_logger/formatters.rb
@@ -1,15 +1,16 @@
 module SemanticLogger
   module Formatters
-    autoload :Base,     "semantic_logger/formatters/base"
-    autoload :Color,    "semantic_logger/formatters/color"
-    autoload :Default,  "semantic_logger/formatters/default"
-    autoload :Json,     "semantic_logger/formatters/json"
-    autoload :Raw,      "semantic_logger/formatters/raw"
-    autoload :OneLine,  "semantic_logger/formatters/one_line"
-    autoload :Signalfx, "semantic_logger/formatters/signalfx"
-    autoload :Syslog,   "semantic_logger/formatters/syslog"
-    autoload :Fluentd,  "semantic_logger/formatters/fluentd"
-    autoload :Logfmt,   "semantic_logger/formatters/logfmt"
+    autoload :Base,      "semantic_logger/formatters/base"
+    autoload :Color,     "semantic_logger/formatters/color"
+    autoload :Default,   "semantic_logger/formatters/default"
+    autoload :Json,      "semantic_logger/formatters/json"
+    autoload :Raw,       "semantic_logger/formatters/raw"
+    autoload :OneLine,   "semantic_logger/formatters/one_line"
+    autoload :Signalfx,  "semantic_logger/formatters/signalfx"
+    autoload :Syslog,    "semantic_logger/formatters/syslog"
+    autoload :Fluentd,   "semantic_logger/formatters/fluentd"
+    autoload :Logfmt,    "semantic_logger/formatters/logfmt"
+    autoload :SyslogCee, "semantic_logger/formatters/syslog_cee"
 
     # Return formatter that responds to call.
     #

--- a/lib/semantic_logger/formatters/syslog_cee.rb
+++ b/lib/semantic_logger/formatters/syslog_cee.rb
@@ -23,7 +23,7 @@ module SemanticLogger
       #
       # Example:
       #   # Log via udp to a remote syslog server on host: `server1` and port `8514`, using the CEE format.
-      #   SemanticLogger.add_appender(appender: :syslog, formatter: syslog_cee, url: 'udp://server1:8514')
+      #   SemanticLogger.add_appender(appender: :syslog, formatter: :syslog_cee, url: 'udp://server1:8514')
       def initialize(facility: ::Syslog::LOG_USER, level_map: SemanticLogger::Formatters::Syslog::LevelMap.new, max_size: Integer)
         @facility  = facility
         @level_map = level_map.is_a?(SemanticLogger::Formatters::Syslog::LevelMap) ? level_map : SemanticLogger::Formatters::Syslog::LevelMap.new(level_map)

--- a/test/formatters/syslog_cee_test.rb
+++ b/test/formatters/syslog_cee_test.rb
@@ -1,0 +1,107 @@
+require_relative "../test_helper"
+require "syslog"
+
+module SemanticLogger
+  module Formatters
+    class SyslogCeeTest < Minitest::Test
+      describe SyslogCee do
+        let(:log_time) do
+          Time.utc(2017, 1, 14, 8, 32, 5.375276)
+        end
+
+        let(:level) do
+          :debug
+        end
+
+        let(:log) do
+          # :level, :thread_name, :name, :message, :payload, :time, :duration, :tags, :level_index, :exception, :metric, :backtrace, :metric_amount, :named_tags
+          log      = SemanticLogger::Log.new("SyslogCeeTest", level)
+          log.time = log_time
+          log
+        end
+
+        let(:expected_time) do
+          SemanticLogger::Formatters::Base::PRECISION == 3 ? "2017-01-14 08:32:05.375" : "2017-01-14 08:32:05.375276"
+        end
+
+        let(:set_exception) do
+          raise "Oh no"
+        rescue Exception => e
+          log.exception = e
+        end
+
+        let(:backtrace) do
+          [
+            "test/formatters/default_test.rb:99:in `block (2 levels) in <class:DefaultTest>'",
+            "gems/ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/spec.rb:247:in `instance_eval'",
+            "gems/ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/spec.rb:247:in `block (2 levels) in let'",
+            "gems/ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/spec.rb:247:in `fetch'",
+            "ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/spec.rb:247:in `block in let'",
+            "test/formatters/default_test.rb:65:in `block (3 levels) in <class:DefaultTest>'",
+            "ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/test.rb:105:in `block (3 levels) in run'"
+          ]
+        end
+
+        let(:appender) do
+          SemanticLogger::Appender::Syslog.new(formatter: :syslog_cee)
+        end
+
+        let(:formatter) do
+          formatter = appender.formatter
+          formatter.max_size = appender.max_size
+          # We need to use logger to test this formatter
+          formatter.call(log, appender.logger)
+          formatter
+        end
+
+        describe "name" do
+          it "logs name" do
+            assert_equal "SyslogCeeTest", formatter.name
+          end
+        end
+
+        describe "call" do
+          it "uses CEE format" do
+            assert_match(/@cee:/, formatter.call(log, appender.logger))
+          end
+
+          it "process log with payload" do
+            log.payload = {is_test: true}
+            assert_match(/"is_test":true/, formatter.call(log, appender.logger))
+          end
+
+          it "includes host name" do
+            formatted_log = formatter.call(log, appender.logger)
+            assert_equal true, formatted_log.include?(appender.logger.host)
+          end
+
+          it "includes application name" do
+            formatted_log = formatter.call(log, appender.logger)
+            assert_equal true, formatted_log.include?(appender.logger.application)
+          end
+
+          it "includes environment" do
+            formatted_log = formatter.call(log, appender.logger)
+            assert_equal true, formatted_log.include?(appender.logger.environment)
+          end
+
+          it "includes correct log level" do
+            assert_match(/"level":"debug"/, formatter.call(log, appender.logger))
+          end
+
+          describe "when exception was raised" do
+            it "logs exception name" do
+              set_exception
+              assert_match(/"name":"RuntimeError"/, formatter.call(log, appender.logger))
+            end
+
+            it "logs exception message" do
+              set_exception
+              assert_match(/"message":"Oh no"/, formatter.call(log, appender.logger))
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Issue # (if available)
None
### Changelog

* Added missing SyslogCee into SemanticLogger::Formatters module
* Added test for SemanticLogger::Formatters::SyslogCee

### Description of changes

After testing the Syslog appender I found a bug that raises exceptions:
```
/usr/local/bundle/gems/semantic_logger-4.11.0/lib/semantic_logger/utils.rb:8:in `const_get': uninitialized constant SemanticLogger::Formatters::SyslogCee (NameError)

        Object.const_get(klass)
              ^^^^^^^^^^
```

It raises when I tried to use SyslogCee formatter
```
SemanticLogger.add_appender(appender: :syslog, formatter: :syslog_cee)
```

There is a simple missing SyslogCee autoload in the SemanticLogger::Formatters module. This Pull Request fixes that issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
