### PR TITLE
Fix a race condition in SemanticLogger.reopen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+
+- Fixes a race condition in `SemancicLogger.reopen`.
+
 ### Changed
 - Contributor experience related to RuboCop was improved with the
   following changes:

--- a/lib/semantic_logger/appender/async.rb
+++ b/lib/semantic_logger/appender/async.rb
@@ -59,7 +59,7 @@ module SemanticLogger
 
         appender.reopen if appender.respond_to?(:reopen)
 
-        @thread.kill if @thread&.alive?
+        @thread&.kill if @thread&.alive?
         @thread = Thread.new { process }
       end
 


### PR DESCRIPTION
### Issue # (if available)

I met ``NoMethodError: undefined method `kill' for nil:NilClass`` in `SemanticLogger.reopen`.

I think [`@thread = nil`](https://github.com/reidmorrison/semantic_logger/blob/8a1650ac90db653849b3082946e02db5c8f6cdd3/lib/semantic_logger/appender/async.rb#L138) can happen between `@thread&.alive?` and `@thread.kill` of [this line](https://github.com/reidmorrison/semantic_logger/blob/8a1650ac90db653849b3082946e02db5c8f6cdd3/lib/semantic_logger/appender/async.rb#L62).

### Changelog

Pull requests will not be accepted without a description of this change under the `[unreleased]` section 
in the file `CHANGELOG`.

### Description of changes



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
