### PR TITLE
fix Logfmt#flatten_log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+- The Logfmt formatter can now parse Hashes and Arrays correctly.
+
 ### Changed
 - Contributor experience related to RuboCop was improved with the
   following changes:

--- a/lib/semantic_logger/formatters/logfmt.rb
+++ b/lib/semantic_logger/formatters/logfmt.rb
@@ -62,7 +62,7 @@ module SemanticLogger
 
       def flatten_log
         flattened = @parsed.map do |key, value|
-          "#{key}=#{value.to_json}"
+          "#{key}=#{value.to_s.to_json}"
         end
 
         flattened.join(" ")

--- a/lib/semantic_logger/formatters/logfmt.rb
+++ b/lib/semantic_logger/formatters/logfmt.rb
@@ -62,7 +62,12 @@ module SemanticLogger
 
       def flatten_log
         flattened = @parsed.map do |key, value|
-          "#{key}=#{value.to_s.to_json}"
+          case value
+          when Hash, Array
+            "#{key}=#{value.to_s.to_json}"
+          else
+            "#{key}=#{value.to_json}"
+          end
         end
 
         flattened.join(" ")

--- a/test/formatters/logfmt_test.rb
+++ b/test/formatters/logfmt_test.rb
@@ -72,6 +72,11 @@ module SemanticLogger
               assert_match(/message="Oh no"/, formatter.call(log, nil))
             end
 
+            it "flattens the stacktrace" do
+              set_exception
+              assert_match(/stack_trace="\[\\"/, formatter.call(log, nil))
+            end
+
             it "changes name to exception" do
               log.payload = {name: "shrek"}
               set_exception


### PR DESCRIPTION
Some objects, like hashes and arrays can be casted to valid json objects. Because of that they were not quoted correctly.

### Issue # (if available)
no issue

### Changelog

* The Logfmt formatter can now parse Hashes and Arrays correctly.

### Description of changes

* The Logfmt formatter can now parse Hashes and Arrays correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
