### PR TITLE
Initialize sentry only if it is not initialized (fixes #218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - Updated RuboCop's target version to Ruby 2.7.5.
     - Updated minimum Ruby version to 2.7.5 as earlier versions are
       end-of-life.
+- Fixes #218 Calls Sentry.init inside sentry_ruby appender only if it is not initialized
 
 ## [4.11.0]
 

--- a/lib/semantic_logger/appender/sentry_ruby.rb
+++ b/lib/semantic_logger/appender/sentry_ruby.rb
@@ -40,7 +40,7 @@ module SemanticLogger
       def initialize(level: :error, **args, &block)
         # Replace the Sentry Ruby logger so that we can identify its log
         # messages and not forward them to Sentry
-        ::Sentry.init { |config| config.logger = SemanticLogger[::Sentry] }
+        ::Sentry.init { |config| config.logger = SemanticLogger[::Sentry] } unless ::Sentry.initialized?
         super(level: level, **args, &block)
       end
 


### PR DESCRIPTION
### Issue #218

### Changelog

Calls Sentry.init inside sentry_ruby appender only if it is not initialized

### Description of changes

These changes allow developers to use their own sentry initializer like this: 

```ruby
# config/initializers/sentry.rb

Sentry.init do |config|
  config.excluded_exceptions += %w[AwesomeCustomError]
  config.logger = SemanticLogger[::Sentry]
  config.traces_sample_rate = 1.0
end
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
