### PR TITLE
Fix log level signal handler to include :fatal and :error levels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - Updated RuboCop's target version to Ruby 2.7.5.
     - Updated minimum Ruby version to 2.7.5 as earlier versions are
       end-of-life.
+- Fixed log level signal handler to include fatal and error levels.
 
 ## [4.11.0]
 

--- a/lib/semantic_logger/semantic_logger.rb
+++ b/lib/semantic_logger/semantic_logger.rb
@@ -279,10 +279,13 @@ module SemanticLogger
   def self.add_signal_handler(log_level_signal = "USR2", thread_dump_signal = "TTIN", gc_log_microseconds = 100_000)
     if log_level_signal
       Signal.trap(log_level_signal) do
-        index     = default_level == :trace ? LEVELS.find_index(:error) : LEVELS.find_index(default_level)
-        new_level = LEVELS[index - 1]
-        self["SemanticLogger"].warn "Changed global default log level to #{new_level.inspect}"
+        current_level_index = LEVELS.find_index(default_level)
+        $stderr.puts "\ncurrent log level is #{current_level_index}: #{default_level}"
+        new_level_index = current_level_index == 0 ? LEVELS.size - 1 : current_level_index - 1
+        new_level = LEVELS[new_level_index]
+        $stderr.puts "new log level is #{new_level_index}: #{new_level}\n\n"
         self.default_level = new_level
+        self["SemanticLogger"].warn "Changed global default log level to #{new_level.inspect}"
       end
     end
 

--- a/lib/semantic_logger/semantic_logger.rb
+++ b/lib/semantic_logger/semantic_logger.rb
@@ -280,10 +280,8 @@ module SemanticLogger
     if log_level_signal
       Signal.trap(log_level_signal) do
         current_level_index = LEVELS.find_index(default_level)
-        $stderr.puts "\ncurrent log level is #{current_level_index}: #{default_level}"
         new_level_index = current_level_index == 0 ? LEVELS.size - 1 : current_level_index - 1
         new_level = LEVELS[new_level_index]
-        $stderr.puts "new log level is #{new_level_index}: #{new_level}\n\n"
         self.default_level = new_level
         self["SemanticLogger"].warn "Changed global default log level to #{new_level.inspect}"
       end


### PR DESCRIPTION
### Issue https://github.com/reidmorrison/semantic_logger/issues/231

### Changelog

- Fixed log level signal handler to include fatal and error levels.

### Description of changes

The log level changer signal handling was omitting the :fatal and :error levels from the cycle of levels. At first I thought it appeared that way only because the log method used was `warn`, but when I used STDERR to log the changes I still did not see `:fatal` and `:warn`.
 
The problem was that the code assumed that `:error` was the highest level, and then subtracted 1 from its level. This code change uses the index boundaries of the `LEVELS` array to guarantee that the correct sequence of levels is used.

For an easy way to illustrate the problem, check out https://gist.github.com/keithrbennett/006c10128ee3a2f37da98b7f013d3951, which uses stderr output instead of the logger.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
