### PR TITLE
Add support for setting the proxy directly for the HTTP appender.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - Updated RuboCop's target version to Ruby 2.7.5.
     - Updated minimum Ruby version to 2.7.5 as earlier versions are
       end-of-life.
-
+- New Feature: Ability to directly set proxy for `SemanticLogger::Appender::Http`
 ## [4.11.0]
 
 - Add kafka client option to use system SSL settings: `ssl_ca_certs_from_system`
-- Support rails tagged logger usage that yields itself: 
+- Support rails tagged logger usage that yields itself:
 ~~~ruby
-Rails.logger.tagged("tag") do |logger| 
+Rails.logger.tagged("tag") do |logger|
   logger.info("Hello World")
 end
 ~~~


### PR DESCRIPTION
In certain configurations you may already need to have the http_proxy env var set but need a different proxy setup for an HTTP appender - or need the HTTP appender to not utilize the environment configuration.

### Changelog

- New Feature: Ability to directly set proxy for `SemanticLogger::Appender::Http`

### Description of changes

- Updated `SemanticLogger::Appender::Http#initialize` to take a `proxy_url` parameter that defaults to `:ENV`.  This value is used internally by `Net::HTTP` to specify that the proxy configuration should be read from the environment, so this should retain the existing behaviour.  Passing in a properly formatted URL (including username/password if necessary) will directly specify the proxy server to use for the appender.  Passing in `nil` will specifiy that the underlying `Net::HTTP` connection **should not** read the proxy configuration from the environment.

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
