### PR TITLE
Hang Due to Async#submit_request Not Waiting for Child Thread to Join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - Updated minimum Ruby version to 2.7.5 as earlier versions are
       end-of-life.
 
+### Fixed
+- Fixed a thread safety issue in Async#submit_request. When closing the async
+  processor, the submit_request method could return before the child thread had
+  finished executing. This caused the program to hang if the child thread
+  dies in the middle of a second call to Async#submit_request. The solution was
+  to wait for the child thread to 'join' before returning.
+
 ## [4.11.0]
 
 - Add kafka client option to use system SSL settings: `ssl_ca_certs_from_system`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   finished executing. This caused the program to hang if the child thread
   dies in the middle of a second call to Async#submit_request. The solution was
   to wait for the child thread to 'join' before returning.
+- AsyncBatch now listens to :close message.
 
 ## [4.11.0]
 

--- a/lib/semantic_logger/appender/async.rb
+++ b/lib/semantic_logger/appender/async.rb
@@ -135,7 +135,6 @@ module SemanticLogger
             nil
           end
         ensure
-          @thread = nil
           # This block may be called after the file handles have been released by Ruby
           begin
             logger.trace("Async: Thread has stopped")
@@ -202,7 +201,9 @@ module SemanticLogger
 
         reply_queue = Queue.new
         queue << {command: command, reply_queue: reply_queue}
-        reply_queue.pop
+        return_value = reply_queue.pop
+        @thread.join if command == :close
+        return_value
       end
     end
   end

--- a/lib/semantic_logger/appender/async_batch.rb
+++ b/lib/semantic_logger/appender/async_batch.rb
@@ -81,7 +81,7 @@ module SemanticLogger
             end
           end
           appender.batch(logs) if logs.size.positive?
-          messages.each { |message| process_message(message) }
+          break unless messages.each { |message| break false unless process_message(message) }
           signal.reset unless queue.size >= batch_size
         end
       end


### PR DESCRIPTION
When closing the async processor, the `Async#submit_request` method can return before the child thread has finished executing. This can cause the program to hang if the child thread dies in the middle of a second call to `Async#submit_request`. The solution is to wait for the child thread to 'join' before returning.

I can reproduce the issue with the following program. Note that you might need to wait several hours for a hang to occur. (Due to thread scheduler differences, I've had the most luck on CentOS 7 and Ubuntu 20.04.) I've included code to get the stack trace so you can see that the program is locked on the expected line:
```
require 'semantic_logger'
require 'stringio'

puts "Run 'kill -SIGUSR1 #{$$}' to get a stack trace once the program hangs."
Signal.trap('USR1') do
  STDERR.puts('Thread Dump')
  Thread.list.each do |thread|
    STDERR.puts
    STDERR.puts(thread.backtrace.join("\n"))
  end
end

# This helps encourage the thread scheduler to switch threads more often. It isn't strictly required
#   for the error to occur, but helps it to occur faster.
2.times do
  Thread.new do
    counter = 0
    while true
      counter = counter + 1
    end    
  end
end

while true
  SemanticLogger.clear_appenders!
  SemanticLogger.add_appender(appender: SemanticLogger::Appender::IO.new(StringIO.new))
  # When the time stops incrementing for a few seconds, the program has hung.
  puts "Current Time : " + Time.new.inspect
end
```
The program hangs on this line:
https://github.com/reidmorrison/semantic_logger/blob/6a7be665a8c6eaf5b9441d8aabc16ec47b3b0231/lib/semantic_logger/appender/async.rb#L205

### Issue # (if available)

* [234](https://github.com/reidmorrison/semantic_logger/issues/234) (My work colleague filed this issue, so I know this is related.)

### Changelog

```
- Fixed a thread safety issue in Async#submit_request. When closing the async
  processor, the submit_request method could return before the child thread had
  finished executing. This caused the program to hang if the child thread
  dies in the middle of a second call to Async#submit_request. The solution was
  to wait for the child thread to 'join' before returning.
```

### Description of changes

* Don't set `@thread` to nil when the thread is stopped. (No behavior seems to depend on that.)
* `join` the child thread before returning from `submit_request` when processing the 'close' command.
* AsyncBatch now listens to :close message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.