### PR TITLE
Prevent multiple calls to Async#close. Wrap Async methods in mutex.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 - The Logfmt formatter can now parse Hashes and Arrays correctly.
 - Fixes a race condition in `SemancicLogger.reopen`.
+- Prevent multiple calls to Async#close.
+- Wrap Async close, flush, create_queue, and reopen methods in a mutex.
 
 ### Changed
 - Contributor experience related to RuboCop was improved with the

--- a/lib/semantic_logger/appender/async.rb
+++ b/lib/semantic_logger/appender/async.rb
@@ -101,10 +101,8 @@ module SemanticLogger
       # Close all appenders and flush any outstanding messages.
       def close
         instance_lock.synchronize do
-          if @close_already_requested
-            # warn "Close already requested on thread #{Thread.current}."
-            return
-          end
+          return if @close_already_requested
+
           @close_already_requested = true
           submit_request(:close)
         end

--- a/lib/semantic_logger/appender/async.rb
+++ b/lib/semantic_logger/appender/async.rb
@@ -111,14 +111,12 @@ module SemanticLogger
       private
 
       def create_queue
-        instance_lock.synchronize do
-          if max_queue_size == -1
-            @queue  = Queue.new
-            @capped = false
-          else
-            @queue  = SizedQueue.new(max_queue_size)
-            @capped = true
-          end
+        if max_queue_size == -1
+          @queue  = Queue.new
+          @capped = false
+        else
+          @queue  = SizedQueue.new(max_queue_size)
+          @capped = true
         end
       end
 

--- a/test/appender/async_test.rb
+++ b/test/appender/async_test.rb
@@ -40,5 +40,15 @@ module Appender
         end
       end
     end
+
+    describe "synchronization" do
+      it "can be reopened without error" do
+        SemanticLogger.clear_appenders!
+        SemanticLogger.add_appender(appender: SemanticLogger::Appender::File.new('/dev/null'), async: true)
+        appender = SemanticLogger.appenders.first
+        assert_instance_of SemanticLogger::Appender::Async, appender
+        appender.reopen
+      end
+    end
   end
 end


### PR DESCRIPTION
### Issue # (if available)

https://github.com/reidmorrison/semantic_logger/issues/234

### Changelog

- Prevent multiple calls to Async#close.
- Wrap Async close, flush, create_queue, and reopen methods in a mutex.

### Description of changes

* Multiple calls to the close method of a given instance of Async can result in errors. This change eliminates the possibility of multiple calls (unless the instance is reopened (i.e. `reopen` is called), in which case the flag is reset and one call can then be made).
* Wraps Async close, flush, create_queue, and reopen methods in a mutex. This eliminates the possibility of more than one call to one of these methods running at the same time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
