### PR TITLE
Add install_eagerly method to Loggable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 - The Logfmt formatter can now parse Hashes and Arrays correctly.
 - Fixes a race condition in `SemancicLogger.reopen`.
+- Add `install_eager` method option to the `Loggable` module, to populate the logger variables before object initialization has completed.
 
 ### Changed
 - Contributor experience related to RuboCop was improved with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 - The Logfmt formatter can now parse Hashes and Arrays correctly.
 - Fixes a race condition in `SemancicLogger.reopen`.
-- Add `install_eager` method option to the `Loggable` module, to populate the logger variables before object initialization has completed.
+- Add `install_eagerly` method option to the `Loggable` module, to populate the logger variables before object initialization has completed.
 
 ### Changed
 - Contributor experience related to RuboCop was improved with the

--- a/lib/semantic_logger/loggable.rb
+++ b/lib/semantic_logger/loggable.rb
@@ -66,7 +66,7 @@ module SemanticLogger
       # logger objects (i.e. @semantic_logger variables).
       #
       # This is necessary if you want to freeze your objects before calling `logger`.
-      def self.install_eager(instance)
+      def self.install_eagerly(instance)
         instance.class.include SemanticLogger::Loggable
         instance.logger
       end

--- a/lib/semantic_logger/loggable.rb
+++ b/lib/semantic_logger/loggable.rb
@@ -60,6 +60,16 @@ module SemanticLogger
           @semantic_logger = logger
         end
       end
+
+      # Call this method in your constructor *instead of* including Loggable
+      # if you want eager (nonlazy) initialization of the class and instance
+      # logger objects (i.e. @semantic_logger variables).
+      #
+      # This is necessary if you want to freeze your objects before calling `logger`.
+      def self.install_eager(instance)
+        instance.class.include SemanticLogger::Loggable
+        instance.logger
+      end
     end
 
     module ClassMethods

--- a/test/loggable_test.rb
+++ b/test/loggable_test.rb
@@ -29,7 +29,7 @@ class AppenderFileTest < Minitest::Test
 
   class EagerClass
     def initialize
-      SemanticLogger::Loggable.install_eager(self)
+      SemanticLogger::Loggable.install_eagerly(self)
     end
   end
 
@@ -77,7 +77,7 @@ class AppenderFileTest < Minitest::Test
     end
 
     describe "eager (nonlazy) initialization" do
-      it "should populate the logger variables when install_eager is used" do
+      it "should populate the logger variables when install_eagerly is used" do
         instance = EagerClass.new
         assert instance.instance_variable_get(:@semantic_logger).is_a?(SemanticLogger::Logger)
         assert instance.class.instance_variable_get(:@semantic_logger).is_a?(SemanticLogger::Logger)

--- a/test/loggable_test.rb
+++ b/test/loggable_test.rb
@@ -27,6 +27,12 @@ class AppenderFileTest < Minitest::Test
     include Process
   end
 
+  class EagerClass
+    def initialize
+      SemanticLogger::Loggable.install_eager(self)
+    end
+  end
+
   describe SemanticLogger::Loggable do
     describe "inheritance" do
       it "should give child classes their own logger" do
@@ -67,6 +73,19 @@ class AppenderFileTest < Minitest::Test
           subclass.process
         end
         assert called, "Did not call the correct logger"
+      end
+    end
+
+    describe "eager (nonlazy) initialization" do
+      it "should populate the logger variables when install_eager is used" do
+        instance = EagerClass.new
+        assert instance.instance_variable_get(:@semantic_logger).is_a?(SemanticLogger::Logger)
+        assert instance.class.instance_variable_get(:@semantic_logger).is_a?(SemanticLogger::Logger)
+      end
+
+      it "should enable freezing the logging object without error" do
+        instance = EagerClass.new
+        instance.freeze
       end
     end
 


### PR DESCRIPTION
### Issue # (if available)

https://github.com/reidmorrison/semantic_logger/issues/233

### Changelog

Add `install_eagerly` method option to the `Loggable` module, to populate the logger variables before object initialization has completed.

### Description of changes

Adds an alternate method of including Loggable in a class (named `SemanticLogger::Loggable.install_eagerly`). This method includes the Loggable module and then calls `logger` on the instance to populate both class and instance variables with the class' logger.

This is necessary in cases where `freeze` is called immediately after object creation and before `logger` is called in the application code. If using the `include ...Loggable` form, there will be a `FrozenError` in this case because the call to logger violates the frozen state of the object by trying to populate the `@semantic_logger` instance variable during the lazy initialization.

It may seem a bit odd not to explicitly `include SemanticLogger::Loggable`, but there is no need to do this because the `install_eagerly` call does that for you.

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
