### PR TITLE
Lost Threads and Hanging Due to Lack of Mutexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - Updated minimum Ruby version to 2.7.5 as earlier versions are
       end-of-life.
 
+### Fixed
+- Fixed a thread safety issue in Async#submit_request. When closing the async
+  processor, the submit_request method could return before the child thread had
+  finished executing. This caused the program to hang if the child thread
+  dies in the middle of a second call to Async#submit_request. The solution was
+  to wait for the child thread to 'join' before returning.
+
 ## [4.11.0]
 
 - Add kafka client option to use system SSL settings: `ssl_ca_certs_from_system`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   finished executing. This caused the program to hang if the child thread
   dies in the middle of a second call to Async#submit_request. The solution was
   to wait for the child thread to 'join' before returning.
+- AsyncBatch now listens to :close message.
 
 ## [4.11.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 - The Logfmt formatter can now parse Hashes and Arrays correctly.
-- Fixes a race condition in `SemancicLogger.reopen`.
 
 ### Changed
 - Contributor experience related to RuboCop was improved with the
@@ -27,6 +26,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   dies in the middle of a second call to Async#submit_request. The solution was
   to wait for the child thread to 'join' before returning.
 - AsyncBatch now listens to :close message.
+- Fixed thread safety issues where appender threads are created and destroyed in
+  multiple threads. Before this fix, Semantic Logger could lose track of
+  appender threads. Consumers could also hang when attempting to flush or close
+  the logger.
 
 ## [4.11.0]
 

--- a/lib/semantic_logger/appender/async.rb
+++ b/lib/semantic_logger/appender/async.rb
@@ -135,7 +135,6 @@ module SemanticLogger
             nil
           end
         ensure
-          @thread = nil
           # This block may be called after the file handles have been released by Ruby
           begin
             logger.trace("Async: Thread has stopped")
@@ -202,7 +201,9 @@ module SemanticLogger
 
         reply_queue = Queue.new
         queue << {command: command, reply_queue: reply_queue}
-        reply_queue.pop
+        return_value = reply_queue.pop
+        @thread.join if command == :close
+        return_value
       end
     end
   end

--- a/lib/semantic_logger/appender/async_batch.rb
+++ b/lib/semantic_logger/appender/async_batch.rb
@@ -81,7 +81,7 @@ module SemanticLogger
             end
           end
           appender.batch(logs) if logs.size.positive?
-          messages.each { |message| process_message(message) }
+          break unless messages.each { |message| break false unless process_message(message) }
           signal.reset unless queue.size >= batch_size
         end
       end

--- a/lib/semantic_logger/processor.rb
+++ b/lib/semantic_logger/processor.rb
@@ -30,10 +30,12 @@ module SemanticLogger
 
     # Start the appender thread
     def start
-      return false if active?
+      thread_mutex.synchronize do
+        return false if active?
 
-      thread
-      true
+        thread
+        true
+      end
     end
   end
 end


### PR DESCRIPTION
### Issue #
None.

### Changelog
```
- Fixed thread safety issues where appender threads are created and destroyed in
  multiple threads. Before this fix, Semantic Logger could lose track of
  appender threads. Consumers could also hang when attempting to flush or close
  the logger.
```

### Description of changes
When adding and clearing appenders from multiple threads (as well as performing similar operations like `SemanticLogger#close`), two problems can occur:
* Semantic Logger can loose track of appender threads. These threads block on reading from the 'queue' and needlessly consume (very few) resources. The bigger issue is that these lost threads will result in a nasty looking "No live threads left. Deadlock?" exception when the program exits.
* Even with my 'join' fix from PR [236](https://github.com/reidmorrison/semantic_logger/pull/236), the async appender can still block on reading from the reply_queue. In addition to locking up the thread, this hang will also result in a deadlock exception when the program exits.

This problem can be demonstrated with the following program:
```
require 'io/console'
require 'semantic_logger'
require 'stringio'

@keep_running = true

# Make sure we have something to 'reopen'.
SemanticLogger.add_appender(appender: SemanticLogger::Appender::IO.new(StringIO.new))

add_appender_threads = []
clear_appender_threads = []
reopen_appender_threads = []
8.times.each do | thread_index |
  add_appender_thread = Thread.new do
    while @keep_running
      STDERR.puts "Hello from add appender thread #{thread_index}.\r"
      SemanticLogger.add_appender(appender: SemanticLogger::Appender::IO.new(StringIO.new))
    end
  end
  add_appender_threads.append(add_appender_thread)

  clear_appender_thread = Thread.new do
    while @keep_running
      STDERR.puts "Hello from clear appenders thread #{thread_index}.\r"
      SemanticLogger.clear_appenders!
    end
  end
  clear_appender_threads.append(clear_appender_thread)

  reopen_appender_thread = Thread.new do
    while @keep_running
      STDERR.puts "Hello from reopen appender thread #{thread_index}.\r"
      SemanticLogger.reopen
    end
  end
  reopen_appender_threads.append(reopen_appender_thread)
end

puts 'Press any key to quit.'
STDIN.getch

@keep_running = false
SemanticLogger.close
add_appender_threads.each do | add_appender_thread |
  add_appender_thread.join
end
clear_appender_threads.each do | clear_appender_thread |
  clear_appender_thread.join
end
reopen_appender_threads.each do | reopen_appender_thread |
  reopen_appender_thread.join
end
```

After letting the program run for a minute or so, upon exit, an error like the following should occur:
```
Traceback (most recent call last):
        4: from noMutexHang2.rb:43:in `<main>'
        3: from /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/semantic_logger.rb:203:in `close'
        2: from /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/appender/async.rb:99:in `close'
        1: from /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/appender/async.rb:204:in `submit_request'
/home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/appender/async.rb:204:in `pop': No live threads left. Deadlock? (fatal)
10 threads, 10 sleeps current:0x00007f129d810a00 main thread:0x00007f12a6a53000
* #<Thread:0x00007f12a6bb6d58 sleep_forever>
   rb_thread_t:0x00007f12a6a53000 native:0x00007f12a6eae180 int:0
   /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/appender/async.rb:204:in `pop'
   /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/appender/async.rb:204:in `submit_request'
   /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/appender/async.rb:99:in `close'
   /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/semantic_logger.rb:203:in `close'
   noMutexHang2.rb:43:in `<main>'
.
.
.
* #<Thread:0x00007f12a1a6f788 noMutexHang2.rb:22 sleep_forever>
   rb_thread_t:0x00007f12a1bb1f00 native:0x00007f129abf5700 int:0
   /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/appender/async.rb:204:in `pop'
   /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/appender/async.rb:204:in `submit_request'
   /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/appender/async.rb:99:in `close'
   /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/semantic_logger.rb:184:in `clear_appenders!'
   noMutexHang2.rb:25:in `block (2 levels) in <main>'
* #<Thread:0x00007f12998e8d68 /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/appender/async.rb:63 sleep_forever>
   rb_thread_t:0x00007f129c0ae780 native:0x00007f1271db1700 int:0
   /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/appender/async.rb:149:in `pop'
   /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/appender/async.rb:149:in `process_messages'
   /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/appender/async.rb:121:in `process'
   /home/jluellwitz/.rvm/gems/ruby-2.7.6/gems/semantic_logger-4.11.0/lib/semantic_logger/appender/async.rb:63:in `block in reopen'
```

While probably not strictly required, this MR builds off my prior PR ([236](https://github.com/reidmorrison/semantic_logger/pull/236)). PR 236 is a bit more urgent as it corrects a threading error when the logger is managed in a single thread. This PR address additional thread safety issues when the logger is managed in multiple threads. I do not believe it makes much sense to merge this PR without the other one although an argument could be made to merge PR 236 without this one.

Admittedly, managing the logger in multiple threads is fairly unlikely, but these changes need to be made to ensure that "Semantic Logger is completely thread safe" and that "all methods can be called concurrently from any thread".

I tried to maintain compatibility with method signatures and behavior as much as possible. The big exception to this is 'Async#reopen'. I cannot implement reopen in a thread safe way and still work around the Ruby 2.5 Queue bug. This shouldn't be much of an issue as you really shouldn't be calling reopen unless you have forked. The work around I had to implement is to only have reopen do something if the appender thread is not running.

I removed the change log entry that reads "Fixes a race condition in `SemancicLogger.reopen`." as this PR completely clobbers znz's PR ([223](https://github.com/reidmorrison/semantic_logger/pull/223)). I should probably point out that znz's change did not really address the race condition as `&.` and `kill` are not executed atomically. `@thread` could still become nil between when `&.` and `kill` are executed. (I can't find any Ruby documentation that directly supports this claim, but the end of this article suggests `@thread&.kill` is not executed atomically: https://lucaguidi.com/2014/03/27/thread-safety-with-ruby/)

Thank you for your consideration. Please let me know if you have any questions.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.