### PR TITLE
Loggable now works with frozen classes and objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [4.13.0]
 
 - Add Minitest helper methods to assist with asserting logging events.
+- Loggable now works with frozen classes and objects.
 
 ## [4.12.0]
 

--- a/lib/semantic_logger/loggable.rb
+++ b/lib/semantic_logger/loggable.rb
@@ -30,6 +30,9 @@
 #     ExternalSupplier.prepend SemanticLogger::Loggable
 module SemanticLogger
   module Loggable
+    LOGGABLE_LOGGERS = Hash.new do |hash, klass|
+      hash[klass] = SemanticLogger[klass]
+    end
     def self.included(base)
       base.extend ClassMethods
       base.singleton_class.class_eval do
@@ -42,7 +45,7 @@ module SemanticLogger
 
         # Returns [SemanticLogger::Logger] class level logger
         def self.logger
-          @semantic_logger ||= SemanticLogger[self]
+          @semantic_logger || SemanticLogger::Loggable::LOGGABLE_LOGGERS[self]
         end
 
         # Replace instance class level logger
@@ -52,7 +55,7 @@ module SemanticLogger
 
         # Returns [SemanticLogger::Logger] instance level logger
         def logger
-          @semantic_logger ||= self.class.logger
+          @semantic_logger || self.class.logger
         end
 
         # Replace instance level logger


### PR DESCRIPTION
### Issue #

[233](https://github.com/reidmorrison/semantic_logger/issues/233)

### Changelog

- Loggable now works with frozen classes and objects.

### Description of changes

Changed the Loggable module to not set any object or class instance variables making Loggable compatible with frozen classes and objects. I'm using a constant Hash in the Loggable module to cache the Loggers so a new one is not created on every use. Changes should be backwards compatible with the current Loggable module and nearly as performant.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
