### PR TITLE
Implement NewRelic Log Formatter & Appender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 - Move `newrelic_rpm.rb` mock to the `test/mocks` directory
 - Add `add_mocks_to_load_path`
+- Add NewRelicLogs formatter & appender
 
 ## [4.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+- Move `newrelic_rpm.rb` mock to the `test/mocks` directory
+- Add `add_mocks_to_load_path`
 
 ## [4.13.0]
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ and are therefore not automatically included by this gem:
 - Bugsnag Appender: gem 'bugsnag'
 - MongoDB Appender: gem 'mongo' 1.9.2 or above
 - NewRelic Appender: gem 'newrelic_rpm'
+- NewRelicLogs Appender: gem 'newrelic_rpm'
 - Syslog Appender: gem 'syslog_protocol' 0.9.2 or above
 - Syslog Appender to a remote syslogng server over TCP or UDP: gem 'net_tcp_client'
 - Splunk Appender: gem 'splunk-sdk-ruby'

--- a/docs/centralized_logging.md
+++ b/docs/centralized_logging.md
@@ -119,6 +119,6 @@ Semantic Logger also supports several other centralized logging solutions:
 * Loggly
 * Syslog
 
-See [appenders](appenders.html) to configure appenders to forward log messages to the centralized logging solutions / log aggregrators.
+See [appenders](appenders.html) to configure appenders to forward log messages to the centralized logging solutions / log aggregators.
 
 ### [Next: Programmers Guide ==>](api.html)

--- a/lib/semantic_logger/appender.rb
+++ b/lib/semantic_logger/appender.rb
@@ -15,6 +15,7 @@ module SemanticLogger
     autoload :Http,              "semantic_logger/appender/http"
     autoload :MongoDB,           "semantic_logger/appender/mongodb"
     autoload :NewRelic,          "semantic_logger/appender/new_relic"
+    autoload :NewRelicLogs,      "semantic_logger/appender/new_relic_logs"
     autoload :Rabbitmq,          "semantic_logger/appender/rabbitmq"
     autoload :Splunk,            "semantic_logger/appender/splunk"
     autoload :SplunkHttp,        "semantic_logger/appender/splunk_http"

--- a/lib/semantic_logger/appender/http.rb
+++ b/lib/semantic_logger/appender/http.rb
@@ -160,10 +160,10 @@ module SemanticLogger
         end
 
         @http = if @proxy_uri
-          Net::HTTP.new(server, port, @proxy_uri.host, @proxy_uri.port, @proxy_uri.user, @proxy_uri.password)
-        else
-          Net::HTTP.new(server, port, @proxy_url)
-        end
+                  Net::HTTP.new(server, port, @proxy_uri.host, @proxy_uri.port, @proxy_uri.user, @proxy_uri.password)
+                else
+                  Net::HTTP.new(server, port, @proxy_url)
+                end
 
         if @ssl_options
           @http.methods.grep(/\A(\w+)=\z/) do |meth|

--- a/lib/semantic_logger/appender/new_relic_logs.rb
+++ b/lib/semantic_logger/appender/new_relic_logs.rb
@@ -50,7 +50,7 @@ module SemanticLogger
       end
 
       def self.log_newrelic(message, level)
-        ::NewRelic::Agent.agent.log_event_aggregrator.record(message, level)
+        ::NewRelic::Agent.agent.log_event_aggregator.record(message, level)
       end
     end
   end

--- a/lib/semantic_logger/appender/new_relic_logs.rb
+++ b/lib/semantic_logger/appender/new_relic_logs.rb
@@ -1,0 +1,57 @@
+begin
+  require "newrelic_rpm"
+rescue LoadError
+  raise LoadError, 'Gem newrelic_rpm is required for logging to New Relic. Please add the gem "newrelic_rpm" to your Gemfile.'
+end
+
+require "semantic_logger/formatters/new_relic_logs"
+
+# Send log messages to NewRelic
+#
+# All log entries will appear under
+# "Logs" in New Relic
+#
+# == Caveats
+#
+# * The NewRelic agent only sends logs to NewRelic when log forwarding is enabled. There is however an open
+#   issue to get this fixed: https://github.com/newrelic/newrelic-ruby-agent/issues/1614. Please see the guide
+#   for a workaround.
+#
+# Example:
+#   SemanticLogger.add_appender(appender: :new_relic_logs)
+module SemanticLogger
+  module Appender
+    class NewRelicLogs < SemanticLogger::Subscriber
+      # Create Appender
+      #
+      # Parameters
+      #   level: [:trace | :debug | :info | :warn | :error | :fatal]
+      #     Override the log level for this appender.
+      #     Default: SemanticLogger.default_level
+      #
+      #   formatter: [Object|Proc]
+      #     An instance of a class that implements #call, or a Proc to be used to format
+      #     the output from this appender
+      #     Default: SemanticLogger::Formatters::NewRelicLogs
+      #
+      #   filter: [Regexp|Proc]
+      #     RegExp: Only include log messages where the class name matches the supplied.
+      #     regular expression. All other messages will be ignored.
+      #     Proc: Only include log messages where the supplied Proc returns true
+      #           The Proc must return true or false.
+      def initialize(formatter: SemanticLogger::Formatters::NewRelicLogs.new, **args, &block)
+        super(formatter: formatter, **args, &block)
+      end
+
+      # Send an error notification to New Relic
+      def log(log)
+        self.class.log_newrelic(formatter.call(log, self).to_json, log.level.to_s.upcase)
+        true
+      end
+
+      def self.log_newrelic(message, level)
+        ::NewRelic::Agent.agent.log_event_aggregrator.record(message, level)
+      end
+    end
+  end
+end

--- a/lib/semantic_logger/formatters.rb
+++ b/lib/semantic_logger/formatters.rb
@@ -1,16 +1,17 @@
 module SemanticLogger
   module Formatters
-    autoload :Base,      "semantic_logger/formatters/base"
-    autoload :Color,     "semantic_logger/formatters/color"
-    autoload :Default,   "semantic_logger/formatters/default"
-    autoload :Json,      "semantic_logger/formatters/json"
-    autoload :Raw,       "semantic_logger/formatters/raw"
-    autoload :OneLine,   "semantic_logger/formatters/one_line"
-    autoload :Signalfx,  "semantic_logger/formatters/signalfx"
-    autoload :Syslog,    "semantic_logger/formatters/syslog"
-    autoload :Fluentd,   "semantic_logger/formatters/fluentd"
-    autoload :Logfmt,    "semantic_logger/formatters/logfmt"
-    autoload :SyslogCee, "semantic_logger/formatters/syslog_cee"
+    autoload :Base,         "semantic_logger/formatters/base"
+    autoload :Color,        "semantic_logger/formatters/color"
+    autoload :Default,      "semantic_logger/formatters/default"
+    autoload :Json,         "semantic_logger/formatters/json"
+    autoload :Raw,          "semantic_logger/formatters/raw"
+    autoload :OneLine,      "semantic_logger/formatters/one_line"
+    autoload :Signalfx,     "semantic_logger/formatters/signalfx"
+    autoload :Syslog,       "semantic_logger/formatters/syslog"
+    autoload :Fluentd,      "semantic_logger/formatters/fluentd"
+    autoload :Logfmt,       "semantic_logger/formatters/logfmt"
+    autoload :SyslogCee,    "semantic_logger/formatters/syslog_cee"
+    autoload :NewRelicLogs, "semantic_logger/formatters/new_relic_logs"
 
     # Return formatter that responds to call.
     #

--- a/lib/semantic_logger/formatters/new_relic_logs.rb
+++ b/lib/semantic_logger/formatters/new_relic_logs.rb
@@ -1,0 +1,109 @@
+require "json"
+
+begin
+  require "newrelic_rpm"
+rescue LoadError
+  raise LoadError, 'Gem newrelic_rpm is required for logging to New Relic. Please add the gem "newrelic_rpm" to your Gemfile.'
+end
+
+raise "NewRelic::Agent.linking_metadata is not defined. Please update newrelic_rpm gem version" unless NewRelic::Agent.respond_to?(:linking_metadata)
+
+raise "NewRelic::Agent::Tracer.current_span_id is not defined. Please update newrelic_rpm gem version" unless NewRelic::Agent::Tracer.respond_to?(:current_span_id)
+
+raise "NewRelic::Agent::Tracer.current_trace_id is not defined. Please update newrelic_rpm gem version" unless NewRelic::Agent::Tracer.respond_to?(:current_trace_id)
+
+module SemanticLogger
+  module Formatters
+    # Formatter for reporting to NewRelic's Logger
+    #
+    # New Relic's logs do not support custom attributes out of the box, and therefore these
+    # have to be put into a single JSON serialized string under the +message+ key.
+    #
+    # In particular the following fields of the log object are serialized under the +message+
+    # key that's sent to NewRelic:
+    #
+    # * message
+    # * tags
+    # * named_tags
+    # * payload
+    # * metric
+    # * metric_amount
+    # * environment
+    # * application
+    #
+    # == New Relic Attributes not Supported
+    # * thread.id
+    # * class.name
+    # * method.name
+    #
+    # == Reference
+    # * Logging specification
+    #   * https://github.com/newrelic/newrelic-exporter-specs/tree/master/logging
+    #
+    # * Metadata APIs
+    #   * https://www.rubydoc.info/gems/newrelic_rpm/NewRelic/Agent#linking_metadata-instance_method
+    #   * https://www.rubydoc.info/gems/newrelic_rpm/NewRelic/Agent/Tracer#current_trace_id-class_method
+    #   * https://www.rubydoc.info/gems/newrelic_rpm/NewRelic/Agent/Tracer#current_span_id-class_method
+    #
+    class NewRelicLogs < Raw
+      def initialize(**args)
+        args.delete(:time_key)
+        args.delete(:time_format)
+
+        super(time_key: :timestamp, time_format: :ms, **args)
+      end
+
+      def call(log, logger)
+        hash = super(log, logger)
+
+        message = {
+          message:    hash[:message].to_s,
+          tags:       hash[:tags] || [],
+          named_tags: hash[:named_tags] || {},
+
+          **hash.slice(:metric, :metric_amount, :environment, :application, :payload)
+        }
+
+        message.merge!(duration: hash[:duration_ms]) if hash.key?(:duration_ms)
+        message.merge!(duration_human: hash[:duration]) if hash.key?(:duration)
+
+        result = {
+          **new_relic_metadata,
+          message:       message.to_json,
+          timestamp:     hash[:timestamp].to_i,
+          "log.level":   log.level.to_s.upcase,
+          "logger.name": log.name,
+          "thread.name": log.thread_name.to_s
+        }
+
+        if hash[:exception]
+          result.merge!(
+            "error.message": hash[:exception][:message],
+            "error.class":   hash[:exception][:name],
+            "error.stack":   hash[:exception][:stack_trace].join("\n")
+          )
+        end
+
+        if hash[:file]
+          result.merge!(
+            "file.name":   hash[:file],
+            "line.number": hash[:line].to_s
+          )
+        end
+
+        result
+      end
+
+      private
+
+      def new_relic_metadata
+        {
+          "trace.id": NewRelic::Agent::Tracer.current_trace_id,
+          "span.id":  NewRelic::Agent::Tracer.current_span_id,
+          **NewRelic::Agent.linking_metadata
+        }.reject { |_k, v| v.nil? }.
+          map { |k, v| [k.to_sym, v] }.to_h
+      end
+    end
+  end
+end

--- a/test/appender/http_test.rb
+++ b/test/appender/http_test.rb
@@ -82,12 +82,12 @@ module Appender
       end
 
       it "uses the ENV proxy if specified" do
-        old_env_proxy = ENV["http_proxy"]
+        old_env_proxy = ENV.fetch("http_proxy", nil)
         ENV["http_proxy"] = "http://user:password@proxy.example.com:12345"
         Net::HTTP.stub_any_instance(:start, true) do
           appender = SemanticLogger::Appender::Http.new(url: "http://ruby-lang.org:8088/path")
 
-          proxy_uri = URI.parse(ENV["http_proxy"])
+          proxy_uri = URI.parse(ENV.fetch("http_proxy", nil))
           assert(appender.http.proxy?)
           assert(appender.http.proxy_from_env?)
           assert_equal(proxy_uri.host, appender.http.proxy_address)
@@ -100,7 +100,7 @@ module Appender
       end
 
       it "doesn't use the ENV proxy if explicity requested" do
-        old_env_proxy = ENV["http_proxy"]
+        old_env_proxy = ENV.fetch("http_proxy", nil)
         ENV["http_proxy"] = "http://user:password@proxy.example.com:12345"
         Net::HTTP.stub_any_instance(:start, true) do
           appender = SemanticLogger::Appender::Http.new(url: "http://ruby-lang.org:8088/path", proxy_url: nil)

--- a/test/appender/new_relic_logs_test.rb
+++ b/test/appender/new_relic_logs_test.rb
@@ -1,0 +1,64 @@
+require_relative "../test_helper"
+
+add_mocks_to_load_path
+
+# Unit Test for SemanticLogger::Appender::NewRelicLogs
+module Appender
+  class NewRelicLogsTest < Minitest::Test
+    describe SemanticLogger::Appender::NewRelicLogs do
+      before do
+        @appender = SemanticLogger::Appender::NewRelicLogs.new
+        @message  = "AppenderNewRelicTest log message"
+      end
+
+      def log_newrelic_stub(message, level)
+        @logged_message = message
+        @logged_level = level
+        @hash = JSON.parse(@logged_message)
+        @message_hash = JSON.parse(@hash["message"])
+      end
+
+      SemanticLogger::Levels::LEVELS.each do |level|
+        it "sends :#{level} notifications to New Relic" do
+          NewRelic::Agent.agent.log_event_aggregrator.stub(:record, method(:log_newrelic_stub)) do
+            @appender.tagged("test") do
+              @appender.send(level, @message)
+            end
+          end
+
+          assert_equal @message, @message_hash["message"]
+          assert_equal ["test"], @message_hash["tags"]
+          assert_nil @message_hash["duration"]
+          assert @hash["thread.name"], @hash.inspect
+          assert_equal @logged_level, level.to_s.upcase
+        end
+      end
+
+      it "send notification to New Relic with custom attributes" do
+        SemanticLogger::Appender::NewRelicLogs.stub(:log_newrelic, method(:log_newrelic_stub)) do
+          SemanticLogger.tagged("test") do
+            SemanticLogger.named_tagged(key1: 1, key2: "a") do
+              @appender.measure_error(message: @message, payload: {key3: 4}) do
+                sleep 0.001
+              end
+            end
+          end
+        end
+
+        assert @hash["thread.name"], @hash.inspect
+
+        assert params = @message_hash, hash
+        assert_equal @message, params["message"]
+        assert params["duration"], params
+        assert_equal ["test"], params["tags"], params
+
+        assert named_tags = params["named_tags"], params
+        assert_equal 1, named_tags["key1"], named_tags
+        assert_equal "a", named_tags["key2"], named_tags
+
+        assert payload = params["payload"], params
+        assert_equal 4, payload["key3"], payload
+      end
+    end
+  end
+end

--- a/test/appender/new_relic_logs_test.rb
+++ b/test/appender/new_relic_logs_test.rb
@@ -20,7 +20,7 @@ module Appender
 
       SemanticLogger::Levels::LEVELS.each do |level|
         it "sends :#{level} notifications to New Relic" do
-          NewRelic::Agent.agent.log_event_aggregrator.stub(:record, method(:log_newrelic_stub)) do
+          NewRelic::Agent.agent.log_event_aggregator.stub(:record, method(:log_newrelic_stub)) do
             @appender.tagged("test") do
               @appender.send(level, @message)
             end

--- a/test/appender/new_relic_test.rb
+++ b/test/appender/new_relic_test.rb
@@ -1,6 +1,6 @@
-# So that the NewRelic appender will load the mock
-$LOAD_PATH.unshift File.dirname(__FILE__)
 require_relative "../test_helper"
+
+add_mocks_to_load_path
 
 # Unit Test for SemanticLogger::Appender::NewRelic
 module Appender

--- a/test/formatters/new_relic_logs_test.rb
+++ b/test/formatters/new_relic_logs_test.rb
@@ -1,0 +1,201 @@
+require_relative "../test_helper"
+
+add_mocks_to_load_path
+
+require "semantic_logger/formatters/new_relic_logs"
+
+require "date"
+
+module SemanticLogger
+  module Formatters
+    class NewRelicLogsTest < Minitest::Test
+      describe NewRelicLogs do
+        let(:log_time) do
+          Time.utc(2017, 1, 14, 8, 32, 5.375276)
+        end
+
+        let(:level) do
+          :debug
+        end
+
+        let(:appender) do
+          SemanticLogger::Appender::NewRelicLogs.new
+        end
+
+        let(:log) do
+          log      = SemanticLogger::Log.new("NewRelicLogsTest", level)
+          log.time = log_time
+          log
+        end
+
+        let(:expected_time) do
+          1_484_382_725_375
+        end
+
+        let(:set_exception) do
+          raise "Oh no"
+        rescue Exception => e
+          log.exception = e
+        end
+
+        let(:expected_exception_backtrace) do
+          log.exception.backtrace.join("\n")
+        end
+
+        let(:backtrace) do
+          [
+            "test/formatters/default_test.rb:99:in `block (2 levels) in <class:DefaultTest>'",
+            "gems/ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/spec.rb:247:in `instance_eval'",
+            "gems/ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/spec.rb:247:in `block (2 levels) in let'",
+            "gems/ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/spec.rb:247:in `fetch'",
+            "ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/spec.rb:247:in `block in let'",
+            "test/formatters/default_test.rb:65:in `block (3 levels) in <class:DefaultTest>'",
+            "ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/test.rb:105:in `block (3 levels) in run'"
+          ]
+        end
+
+        let(:formatted_log) do
+          formatter = appender.formatter
+          formatter.call(log, appender.logger)
+        end
+
+        let(:message_hash) do
+          JSON.parse(formatted_log[:message])
+        end
+
+        describe "time" do
+          it "logs time" do
+            assert_equal expected_time, formatted_log[:timestamp]
+          end
+        end
+
+        describe "level" do
+          it "logs long name" do
+            assert_equal "DEBUG", formatted_log[:"log.level"]
+          end
+        end
+
+        describe "process_info" do
+          it "logs thread name" do
+            assert_equal Thread.current.name, formatted_log[:"thread.name"]
+          end
+
+          it "logs pid, thread name, and file name" do
+            set_exception
+            log.backtrace = backtrace
+            assert_equal Thread.current.name, formatted_log[:"thread.name"]
+            assert_equal "test/formatters/default_test.rb", formatted_log[:"file.name"]
+            assert_equal "99", formatted_log[:"line.number"]
+          end
+        end
+
+        describe "tags" do
+          it "logs tags" do
+            log.tags = %w[first second third]
+            assert_equal log.tags, message_hash["tags"]
+          end
+        end
+
+        describe "named_tags" do
+          it "logs named tags" do
+            log.named_tags = {first: 1, second: 2, third: 3}
+            assert_equal(
+              {"first" => 1, "second" => 2, "third" => 3},
+              message_hash["named_tags"]
+            )
+          end
+        end
+
+        describe "duration" do
+          it "logs long duration" do
+            log.duration = 1_000_000.34567
+            assert_equal log.duration, message_hash["duration"]
+          end
+
+          it "logs short duration" do
+            log.duration = 1.34567
+            duration     = SemanticLogger::Formatters::Base::PRECISION == 3 ? "1ms" : "1.346ms"
+
+            assert_equal duration, message_hash["duration_human"]
+            assert_equal log.duration, message_hash["duration"]
+          end
+        end
+
+        describe "name" do
+          it "logs name" do
+            assert_equal "NewRelicLogsTest", formatted_log[:"logger.name"]
+          end
+        end
+
+        describe "message" do
+          it "logs message" do
+            log.message = "Hello World"
+            assert_equal "Hello World", message_hash["message"]
+          end
+
+          it "keeps empty message" do
+            assert_equal "", message_hash["message"]
+          end
+        end
+
+        describe "payload" do
+          it "logs hash payload" do
+            log.payload = {first: 1, second: 2, third: 3}
+            assert_equal(
+              {"first" => 1, "second" => 2, "third" => 3},
+              message_hash["payload"]
+            )
+          end
+
+          it "skips nil payload" do
+            refute message_hash["payload"]
+          end
+
+          it "skips empty payload" do
+            log.payload = {}
+            refute message_hash["payload"]
+          end
+        end
+
+        describe "exception" do
+          it "skips nil exception" do
+            refute formatted_log[:"error.message"]
+            refute formatted_log[:"error.class"]
+            refute formatted_log[:"error.stack"]
+          end
+        end
+
+        describe "call" do
+          it "retuns all elements" do
+            log.tags       = %w[first second third]
+            log.named_tags = {first: 1, second: 2, third: 3}
+            log.duration   = 1.34567
+            log.message    = "Hello World"
+            log.payload    = {first: 1, second: 2, third: 3}
+            log.backtrace  = backtrace
+            set_exception
+            duration = SemanticLogger::Formatters::Base::PRECISION == 3 ? "1" : "1.346"
+
+            expected_hash = {
+              "entity.name":   "Entity Name",
+              "entity.type":   "SERVICE",
+              hostname:        "hostname",
+              message:         "{\"message\":\"Hello World\",\"tags\":[\"first\",\"second\",\"third\"],\"named_tags\":{\"first\":1,\"second\":2,\"third\":3},\"environment\":\"test\",\"application\":\"Semantic Logger\",\"payload\":{\"first\":1,\"second\":2,\"third\":3},\"duration\":1.34567,\"duration_human\":\"1.346ms\"}",
+              timestamp:       1_484_382_725_375,
+              "log.level":     "DEBUG",
+              "logger.name":   "NewRelicLogsTest",
+              "thread.name":   Thread.current.name,
+              "error.message": "Oh no",
+              "error.class":   "RuntimeError",
+              "error.stack":   expected_exception_backtrace,
+              "file.name":     "test/formatters/default_test.rb",
+              "line.number":   "99"
+            }
+
+            assert_equal expected_hash, formatted_log
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -118,7 +118,7 @@ class LoggerTest < Minitest::Test
           end
 
           it "logs message without modifying the supplied hash" do
-            details = { message: "hello world" }
+            details = {message: "hello world"}
             logger.send(level, details)
 
             assert log = log_message

--- a/test/mocks/newrelic_rpm.rb
+++ b/test/mocks/newrelic_rpm.rb
@@ -2,6 +2,19 @@
 
 module NewRelic
   module Agent
+    module LogEventAggregrator
+      def self.record(message, level)
+      end
+    end
+
+    def self.agent
+      self
+    end
+
+    def self.log_event_aggregrator
+      LogEventAggregrator
+    end
+
     def self.notice_error(message, hash)
     end
 
@@ -12,7 +25,7 @@ module NewRelic
     end
 
     def self.linking_metadata
-      {"entity.name"=>"Entity Name", "entity.type"=>"SERVICE", "hostname"=>"hostname"}
+      {"entity.name" => "Entity Name", "entity.type" => "SERVICE", "hostname" => "hostname"}
     end
 
     module Tracer

--- a/test/mocks/newrelic_rpm.rb
+++ b/test/mocks/newrelic_rpm.rb
@@ -10,5 +10,17 @@ module NewRelic
 
     def self.increment_metric(name, count = 1)
     end
+
+    def self.linking_metadata
+      {"entity.name"=>"Entity Name", "entity.type"=>"SERVICE", "hostname"=>"hostname"}
+    end
+
+    module Tracer
+      def self.current_trace_id
+      end
+
+      def self.current_span_id
+      end
+    end
   end
 end

--- a/test/mocks/newrelic_rpm.rb
+++ b/test/mocks/newrelic_rpm.rb
@@ -2,7 +2,7 @@
 
 module NewRelic
   module Agent
-    module LogEventAggregrator
+    module LogEventAggregator
       def self.record(message, level)
       end
     end
@@ -11,8 +11,8 @@ module NewRelic
       self
     end
 
-    def self.log_event_aggregrator
-      LogEventAggregrator
+    def self.log_event_aggregator
+      LogEventAggregator
     end
 
     def self.notice_error(message, hash)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,3 +32,7 @@ class Minitest::Test
     }
   end
 end
+
+def add_mocks_to_load_path
+  $LOAD_PATH.unshift File.join(File.dirname(__FILE__), "mocks")
+end


### PR DESCRIPTION
### Issue #222

### Changelog
- [x] Pull requests will not be accepted without a description of this change under the `[unreleased]` section 
in the file `CHANGELOG`.

### Description of changes
- Implement a Formatter for NewRelic logs
- Implement an Appender for NewRelic logs
- Add new methods to mocks to support the above

### Questions
-  Should I include parameters such as thread name also as custom parameter, or will including it in the NR envelope suffice?
- `Appender::NewRelic`'s test asserts that metrics should not be sent, must this be the same for logs? 
- The mock I did inside the `Appender::NewRelicLogs` does not currently stub out the NR code, this might be an issue as the code inside `AppenderNewRelic.log_newrelic` is not being excercised, should I change this

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
