### PR TITLE
Add Ruby 3.2 and quote 3.0 in CI configuration so it is not truncated to 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, "3.0", 3.1]
+        ruby: [2.7, "3.0", 3.1, 3.2]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0, 3.1]
+        ruby: [2.7, "3.0", 3.1]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Quote 3.0 in CI configuration to prevent truncation.
+
 ## [4.13.0]
 
 - Add Minitest helper methods to assist with asserting logging events.


### PR DESCRIPTION
### Issue # (if available)

The unquoted 3.0 in the CI configuration gets truncated to '3', and causes the latest Ruby 3 to be loaded.  That's a 3.1 version at this time.  This can be seen below:

<img width="1063" alt="Screenshot 2022-11-27 at 12 15 26 PM" src="https://user-images.githubusercontent.com/421488/204150062-2aed5898-2eeb-4b08-a2d3-e23d882f0152.png">

As the intention of this entry is to load a 3.0.x Ruby, this is a bug.  

### Changelog

Quote 3.0 in CI configuration to prevent truncation.

### Description of changes

Quoting the 3.0 ensures that a Ruby 3.0.x version is loaded for that entry in the CI matrix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
