### PR TITLE
Bug: Missing key in logging payload causes tests to pass in Minitest helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Add payload logging to `payload_includes` Minitest helper functionality.
+- Fix bug in `payload_includes` testing functionality where if a key is not in the payload the test would pass.
+
 ## [4.13.0]
 
 - Add Minitest helper methods to assist with asserting logging events.

--- a/lib/semantic_logger/test/minitest.rb
+++ b/lib/semantic_logger/test/minitest.rb
@@ -26,18 +26,20 @@ module SemanticLogger
         assert_includes event.message, message_includes if message_includes
         assert_equal name, event.name, -> { "Mismatched log name for message: '#{msg}'" } if name
         assert_equal level, event.level, -> { "Mismatched log level for message: '#{msg}'" } if level
+
         if payload_includes
           payload_includes.each_pair do |key, expected_value|
             value = event.payload[key]
-            if value.nil?
-              assert_nil value, -> { "Mismatched key: #{key.inspect} in log payload for message: '#{msg}'" }
+            if expected_value.nil?
+              assert_nil value, -> { "Mismatched key: #{key.inspect} in log payload: #{event.payload} for message: '#{msg}'" }
             else
-              assert_equal expected_value, value, -> { "Mismatched key: #{key.inspect} in log payload for message: '#{msg}'" }
+              assert_equal expected_value, value, -> { "Mismatched key: #{key.inspect} in log payload: #{event.payload} for message: '#{msg}'" }
             end
           end
         elsif payload
-          assert_equal payload, event.payload, -> { "Mismatched log payload for message: '#{msg}'" }
+          assert_equal payload, event.payload, -> { "Mismatched log payload: #{event.payload} for message: '#{msg}'" }
         end
+
         assert_equal thread_name, event.thread_name, -> { "Mismatched thread_name for message: '#{msg}'" } if thread_name
         assert_equal tags, event.tags, -> { "Mismatched tags for message: '#{msg}'" } if tags
         assert_equal named_tags, event.named_tags, -> { "Mismatched named_tags for message: '#{msg}'" } if named_tags


### PR DESCRIPTION
Thanks for adding these test helpers, they've made testing functionality very easy. I ran into a couple of issues where tests would pass when I didn't expect them to which led me to raise this PR.

### Description of changes

If the payload being tested does not contain the key you're checking for then the test will pass. The expectation is that the test should fail and report what was found in the payload instead.

The below changes do the following:
- Only assert nil when the `expected_value` is nil instead of the actual value. 
- Add the event payload to the failing test output. The log message does not contain this information and makes it difficult to debug.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
