### PR TITLE
[WIP] Base formatter time format docs and behavior conflict, with no way to initialize it to nil in the ctor.

### DIFF
--- a/test/formatters/base_test.rb
+++ b/test/formatters/base_test.rb
@@ -1,0 +1,31 @@
+require_relative "../test_helper"
+
+module SemanticLogger
+  module Formatters
+    class TimeFormatTestFormatter < Base
+      def initialize
+        super(time_format: nil)
+      end
+    end
+
+    class BaseTest < Minitest::Test
+      describe Base do
+        let(:formatter) { TimeFormatTestFormatter.new }
+
+        it 'when nil is passed as the formatter, the time_format property is nil' do
+          assert_nil(formatter.time_format)
+        end
+
+        it 'when nil is passed as the formatter, no time will be output' do
+          assert_equal(formatter.send(:format_time, Time.now), '')
+        end
+
+        it 'does suppress time output if time_format is set to nil post-initialization' do
+          formatter.time_format = nil
+          assert_nil(formatter.time_format)
+          assert_equal(formatter.send(:format_time, Time.now), '')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Issue # 

https://github.com/reidmorrison/semantic_logger/issues/259

The documentation and behavior for the Base formatter (lib/semantic_logger/formatters/base.rb) conflict. See the above issue for details.

### Changelog

This PR is not (yet) intended to be merged, so I have marked it WIP and not added any entries to the Changelog.

### Description of changes

A test file has been added which illustrates the conflict, and shows how one can work around it if one wants to set the time_format to nil. (That is, to call `time_format=` method, passing nil, _after_ the formatter is initialized.)

The two test failures are intentional, to illustrate the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
