### PR TITLE
Add support for custom headers in HTTP appender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Add support for custom headers in HTTP appender.
+
 ## [4.13.0]
 
 - Replace `autoload` with `require` for most requires since Ruby does not allow a require

--- a/lib/semantic_logger/appender/http.rb
+++ b/lib/semantic_logger/appender/http.rb
@@ -48,6 +48,11 @@ module SemanticLogger
       #   password: [String]
       #     Password for basic Authentication.
       #
+      #   header: [Hash]
+      #     Custom HTTP headers to send with each request.
+      #     Default: {} ( do not send any custom headers)
+      #     Example: {"Authorization" => "Bearer BEARER_TOKEN"}
+      #
       #   compress: [true|false]
       #     Whether to compress the JSON string with GZip.
       #     Default: false
@@ -95,6 +100,7 @@ module SemanticLogger
                      ssl: {},
                      username: nil,
                      password: nil,
+                     header: {},
                      proxy_url: :ENV,
                      open_timeout: 2.0,
                      read_timeout: 1.0,
@@ -118,7 +124,7 @@ module SemanticLogger
           "Content-Type" => "application/json",
           "Connection"   => "keep-alive",
           "Keep-Alive"   => "300"
-        }
+        }.merge(header)
         @header["Content-Encoding"] = "gzip" if @compress
 
         uri     = URI.parse(@url)

--- a/test/appender/http_test.rb
+++ b/test/appender/http_test.rb
@@ -59,6 +59,18 @@ module Appender
         end
       end
 
+      it "supports custom headers" do
+        Net::HTTP.stub_any_instance(:start, true) do
+          request = nil
+          header = {"Authorization" => "Bearer BEARER_TOKEN"}
+          appender = SemanticLogger::Appender::Http.new(url: "http://localhost:8088/path", header: header)
+          appender.http.stub(:request, ->(r) { request = r; response_mock.new("200", "ok") }) do
+            appender.send(:info, @message)
+          end
+          assert_equal(header["Authorization"], request["Authorization"])
+        end
+      end
+
       # We need to use a valid address that doesn't resolve to a localhost
       # address in order to check the proxy.  Net::HTTP uses URI::Generic#find_proxy
       # to determine the proxy to use, which will return nil if the hostname resolves


### PR DESCRIPTION
### Issue #252

### Changelog

Updated.

### Description of changes

Add support for custom headers in HTTP appender. Among other things, this makes it possible to use the HTTP appender with endpoints that use [Bearer auth](https://datatracker.ietf.org/doc/html/rfc6750), like [Logtail's REST API](https://betterstack.com/docs/logs/http-rest-api/).
