### PR TITLE
Adds support for newer versions of Elasticsearch that removed _type in Elasticsearch Appender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Add support for Elasticsearch 7.x and 8.x in the Elasticsearch appender.
 - Add support for custom headers in HTTP appender.
 
 ## [4.13.0]

--- a/lib/semantic_logger/appender/elasticsearch_http.rb
+++ b/lib/semantic_logger/appender/elasticsearch_http.rb
@@ -26,6 +26,7 @@ module SemanticLogger
       #
       #   type: [String]
       #     Document type to associate with logs when they are written.
+      #     Deprecated in Elasticsearch 7.0.0
       #     Default: 'log'
       #
       #   level: [:trace | :debug | :info | :warn | :error | :fatal]

--- a/test/appender/elasticsearch_test.rb
+++ b/test/appender/elasticsearch_test.rb
@@ -4,12 +4,20 @@ require_relative "../test_helper"
 module Appender
   class ElasticsearchTest < Minitest::Test
     describe SemanticLogger::Appender::Elasticsearch do
+      let :client_class do
+        if Gem::Version.new(::Elasticsearch::VERSION) < Gem::Version.new(8)
+          Elasticsearch::Transport::Client
+        else
+          Elasticsearch::Client
+        end
+      end
+
       describe "providing a url" do
         let :appender do
           if ENV["ELASTICSEARCH"]
             SemanticLogger::Appender::Elasticsearch.new(url: "http://localhost:9200")
           else
-            Elasticsearch::Transport::Client.stub_any_instance(:bulk, true) do
+            client_class.stub_any_instance(:bulk, true) do
               SemanticLogger::Appender::Elasticsearch.new(url: "http://localhost:9200")
             end
           end
@@ -138,7 +146,7 @@ module Appender
               data_stream: true
             )
           else
-            Elasticsearch::Transport::Client.stub_any_instance(:bulk, true) do
+            client_class.stub_any_instance(:bulk, true) do
               SemanticLogger::Appender::Elasticsearch.new(
                 url: "http://localhost:9200",
                 data_stream: true
@@ -220,7 +228,7 @@ module Appender
 
       describe "elasticsearch parameters" do
         let :appender do
-          Elasticsearch::Transport::Client.stub_any_instance(:bulk, true) do
+          client_class.stub_any_instance(:bulk, true) do
             SemanticLogger::Appender::Elasticsearch.new(
               hosts: [{host: "localhost", port: 9200}]
             )


### PR DESCRIPTION
### Issue #225

### Description of changes

Adds support for newer versions of Elasticsearch that removed _type in Elasticsearch Appender.

Hi @reidmorrison,
I tested this code with 6.x, 7.x and 8.x. For integrating the tests with the different versions, I think we would need to add different gemfiles and run the tests with each version, but I don't know if that's worth it or something you'd like to have since it'd be quite an overhead. Let me know.

I added a helper function to the tests. For versions < 8.0.0, `Elasticsearch::Transport::Client` and `Elasticsearch::Client` could be used to call `bulk`, but since we extracted Transport into its own library, you need to call `Elasticsearch::Client` for bulk.

Let me know what you think. For `ElasticsearchHTTP`, you'd need to make a call to `/` in the Elasticsearch instance to find out the version, and if it's 7 or 8 remove `type` from the path. Let me know if you'd like me to add this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
