### PR TITLE
Add Ruby 3.3 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, "3.0", 3.1, 3.2]
+        ruby: [2.7, "3.0", 3.1, 3.2, 3.3]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Add support for Ruby 3.3
+
 ## [4.15.0]
 
 - Add support for Elasticsearch 7.x and 8.x in the Elasticsearch appender.


### PR DESCRIPTION
### Issue # (if available)
This PR adds Ruby 3.3 to CI matrix

### Changelog

Support Ruby 3.3

### Description of changes

Support Ruby 3.3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
