### PR TITLE
Add duration and duration_ms for logfmt format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add support for Ruby 3.3
 - Allow SyncProcessor to be called from appenders
 - Fix incorrect metrics usage examples in documentation
+- Add `:duration_ms` to Logfmt fomatter
 
 ## [4.15.0]
 

--- a/lib/semantic_logger/formatters/logfmt.rb
+++ b/lib/semantic_logger/formatters/logfmt.rb
@@ -31,7 +31,7 @@ module SemanticLogger
       private
 
       def raw_to_logfmt
-        @parsed = @raw.slice(time_key, :level, :name, :message, :duration).merge(tag: "success")
+        @parsed = @raw.slice(time_key, :level, :name, :message, :duration, :duration_ms).merge(tag: "success")
         handle_tags
         handle_payload
         handle_exception


### PR DESCRIPTION
### Changelog

Pull requests will not be accepted without a description of this change under the `[unreleased]` section 
in the file `CHANGELOG`.

### Description of changes

Add :duration_ms to Logfmt formatter
Log processors sometimes parse duration_human as string (because of the added 'ms') which is not always useful.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
