### PR TITLE
Allow SyncProcessor to be called from appenders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Add support for Ruby 3.3
+- Allow SyncProcessor to be called from appenders
 
 ## [4.15.0]
 

--- a/lib/semantic_logger/sync_processor.rb
+++ b/lib/semantic_logger/sync_processor.rb
@@ -2,26 +2,26 @@ module SemanticLogger
   # The SyncProcessor performs logging in the current thread.
   #
   # Appenders are designed to only be used by one thread at a time, so all calls
-  # are mutex protected in case SyncProcessor is being used in a multi-threaded environment.
+  # are monitor protected in case SyncProcessor is being used in a multi-threaded environment.
   class SyncProcessor
     def add(*args, &block)
-      @mutex.synchronize { @appenders.add(*args, &block) }
+      @monitor.synchronize { @appenders.add(*args, &block) }
     end
 
     def log(*args, &block)
-      @mutex.synchronize { @appenders.log(*args, &block) }
+      @monitor.synchronize { @appenders.log(*args, &block) }
     end
 
     def flush
-      @mutex.synchronize { @appenders.flush }
+      @monitor.synchronize { @appenders.flush }
     end
 
     def close
-      @mutex.synchronize { @appenders.close }
+      @monitor.synchronize { @appenders.close }
     end
 
     def reopen(*args)
-      @mutex.synchronize { @appenders.reopen(*args) }
+      @monitor.synchronize { @appenders.reopen(*args) }
     end
 
     # Allow the internal logger to be overridden from its default of $stderr
@@ -47,7 +47,7 @@ module SemanticLogger
     attr_reader :appenders
 
     def initialize(appenders = nil)
-      @mutex     = Mutex.new
+      @monitor   = Monitor.new
       @appenders = appenders || Appenders.new(self.class.logger.dup)
     end
 


### PR DESCRIPTION
SyncProcessor#log could be called recursively from an appender like Bugsnag and Sentry.

### Issue # (if available)

#281

### Changelog

Allow SyncProcessor to be called from appenders

### Description of changes

SyncProcessor#log could be called recursively from an appender like Bugsnag and Sentry. However, SyncProcessor doesn't allow it because it uses Mutex to protect SyncProcessor#log. Here are code snippets to reproduce the Mutex error.

```ruby
require 'semantic_logger/sync'
require 'sentry-ruby'

SemanticLogger.add_appender(appender: :sentry_ruby)

Sentry.init do |config|
  config.logger = SemanticLogger[Sentry]
  config.background_worker_threads = 0
  config.dsn = 'http://foo@localhost/bar'
end

logger = SemanticLogger['MyClass']
begin
  raise 'something went wrong'
rescue => e
  logger.error('oops', e)
end
```

```ruby
require 'semantic_logger/sync'
require 'bugsnag'

ENV['BUGSNAG_API_KEY'] = '0123456789abcdef0123456789abcdef'

SemanticLogger.add_appender(appender: :bugsnag)

logger = SemanticLogger['MyClass']
begin
  raise 'something went wrong'
rescue => e
  logger.error('oops', e)
end
```

This PR resolves the issue by replacing Mutex with Monitor. Monitor allows to enter the critical section if the Mutex's owner is the current thread.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
