### PR TITLE
Fix incorrect metrics usage in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Add support for Ruby 3.3
+- Fix incorrect metrics usage examples in documentation
 
 ## [4.15.0]
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -69,7 +69,7 @@ Send metrics to [Statsd](https://github.com/quasor/statsd) via UDP so it can rol
 [graphite](http://graphite.wikidot.com/) or [mongodb](http://mongodb.org).
 
 ~~~ruby
-subscriber = SemanticLogger::Metrics::Statsd.new(url: "udp://localhost:8125")
+subscriber = SemanticLogger::Metric::Statsd.new(url: "udp://localhost:8125")
 SemanticLogger.on_log(subscriber)
 ~~~
 
@@ -78,7 +78,7 @@ SemanticLogger.on_log(subscriber)
 To forward metrics to New Relic so that they can be displayed using custom dashboards:
 
 ~~~ruby
-subscriber = SemanticLogger::Metrics::NewRelic.new
+subscriber = SemanticLogger::Metric::NewRelic.new
 SemanticLogger.on_log(subscriber)
 ~~~
 


### PR DESCRIPTION
Replace `SemanticLogger::Metrics` with `SemanticLogger::Metric`

### Issue # (if available)

Fixes issue #283

### Changelog

- Fix incorrect metrics usage examples in documentation

### Description of changes

The documentation incorrectly states that metrics subscribers can be added via `SemanticLogger::Metrics`. This was added in #35cb18c0 but the code was refactored in #e848e327, causing the documentation to become out of date. This PR fixes the documentation to use `SemanticLogger::Metric` instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
