### PR TITLE
fix: Use correct varname for closed appenders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix regression in `SemanticLogger::Appenders#close`
+
 ## [4.16.0]
 
 - Add appender for Honeybadger Insights using the events API

--- a/lib/semantic_logger/appenders.rb
+++ b/lib/semantic_logger/appenders.rb
@@ -49,9 +49,9 @@ module SemanticLogger
       closed_appenders = []
       each do |appender|
         logger.trace "Closing appender: #{appender.name}"
-        appenders << appender
         appender.flush
         appender.close
+        closed_appenders << appender
       rescue Exception => e
         logger.error "Failed to close appender: #{appender.name}", e
       end

--- a/test/appenders_test.rb
+++ b/test/appenders_test.rb
@@ -100,5 +100,16 @@ class AppendersTest < Minitest::Test
       #   assert_instance_of SemanticLogger::Appender::Async, appender
       # end
     end
+
+    describe "#close" do
+      it "closes appenders" do
+        appender = appenders.add(file_name: "test.log")
+
+        appenders.close
+
+        assert_equal 0, capture_logger.events.count { |it| it.message.match?(/failed/i) }
+        assert_equal 0, appenders.size
+      end
+    end
   end
 end


### PR DESCRIPTION
### Changelog

- Fix regression in `SemanticLogger::Appenders#close`

### Description of changes

Backported (from v5) changes to `#close` track list of closed appenders. Unfortunately, the variable name used for tracking is `closed_appenders`, while in the loop we're trying to add the closed appender into non-existing variable `appenders`.

This patch fixes the issue. Also, I moved `closed_appenders << appender` after the fact of closure, so that the returned list is correct in case of either `flush` or `close` failed.

---

Closes: https://github.com/reidmorrison/semantic_logger/issues/291

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
