### PR TITLE
Fix Appenders#close referencing incorrect variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+- Fix Appenders#close referencing incorrect variable (#294)
 
 ## [4.16.0]
 

--- a/lib/semantic_logger/appenders.rb
+++ b/lib/semantic_logger/appenders.rb
@@ -49,7 +49,7 @@ module SemanticLogger
       closed_appenders = []
       each do |appender|
         logger.trace "Closing appender: #{appender.name}"
-        appenders << appender
+        closed_appenders << appender
         appender.flush
         appender.close
       rescue Exception => e


### PR DESCRIPTION
### Issue #291

### Changelog

Pull requests will not be accepted without a description of this change under the `[unreleased]` section 
in the file `CHANGELOG`.

### Description of changes

On 4.16.0, `Appenders#close` is referencing a non-existant variable `appenders` instead of `closed_appenders`, which looks it was left like that by mistake, causing errors when calling `SemanticLogger#close_appenders!`

This PR includes the fix proposed by @jesseyoungmann on Issue #291

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
