### PR TITLE
Correct `source_code_uri` URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Correct `source_code_uri` URL
 
 ## [4.16.1]
 

--- a/semantic_logger.gemspec
+++ b/semantic_logger.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.metadata = {
     "bug_tracker_uri"       => "https://github.com/reidmorrison/semantic_logger/issues",
     "documentation_uri"     => "https://logger.rocketjob.io",
-    "source_code_uri"       => "https://github.com/reidmorrison/semantic_logger/tree/#{SemanticLogger::VERSION}",
+    "source_code_uri"       => "https://github.com/reidmorrison/semantic_logger/tree/v#{SemanticLogger::VERSION}",
     "rubygems_mfa_required" => "true"
   }
 end


### PR DESCRIPTION
### Issue # (if available)

### Changelog

- [x] Pull requests will not be accepted without a description of this change under the `[unreleased]` section in the file `CHANGELOG`.

### Description of changes

There was a missing `v` before the interpolated version number causing links published on RubyGems.org to 404.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
