### PR TITLE
Docs: fix example custom formatter

### DIFF
--- a/docs/customize.md
+++ b/docs/customize.md
@@ -74,7 +74,7 @@ Create a custom formatter:
 class MyFormatter < SemanticLogger::Formatters::Color
   # Return the complete log level name in uppercase
   def level
-    "#{color}log.level.upcase#{clear}"
+    "#{color}#{log.level.upcase}#{color_map.clear}"
   end
 end
 ~~~


### PR DESCRIPTION
Fix some invalid example code in the docs.

I'm unsure on whether you want this added to the changelog. Assuming no, since it's only docs, and doesn't require a release. Let me know if my assumption is wrong.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
