### PR TITLE
fix: ensure logger debug calls always return true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Correct `source_code_uri` URL
+- Modify the logger debug behavior to return true regardless of the log level, ensuring dependent processes like state machines in solidus function correctly
 
 ## [4.16.1]
 

--- a/lib/semantic_logger/base.rb
+++ b/lib/semantic_logger/base.rb
@@ -80,12 +80,8 @@ module SemanticLogger
     SemanticLogger::Levels::LEVELS.each_with_index do |level, index|
       class_eval <<~METHODS, __FILE__, __LINE__ + 1
         def #{level}(message=nil, payload=nil, exception=nil, &block)
-          if level_index <= #{index}
-            log_internal(:#{level}, #{index}, message, payload, exception, &block)
-            true
-          else
-            false
-          end
+          log_internal(:#{level}, #{index}, message, payload, exception, &block) if level_index <= #{index}
+          true
         end
 
         def #{level}?


### PR DESCRIPTION
### Issue #304 

### Description of changes
Modify logger debug behavior to return true regardless of the log level, ensuring dependent processes like state machines in solidus function correctly

### Context
In Rails’ default logger, a call to `logger.debug` always returns `true` regardless of the log level, preserving compatibility with code that relies on the return value. However, rails_semantic_logger deviates from this behavior, returning `false` when the log level does not allow the message to be logged. This discrepancy can cause unexpected issues in frameworks like Solidus or other applications using state machines or similar logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
