### PR TITLE
Newrelic Logs Integration: Unnest messages/named_tags, leverage nested objects, quick hacky Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Exclude unnecessary files
+.git
+.bundle
+tmp/
+log/
+coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - Correct `source_code_uri` URL
+- NR Integration: Ensures key/values are not nested under `messages`
+- NR Integration: Ensures structures are built for all nested json (I.E build an actual object instead of doing `span.id` as the key)
+- NR Integration: Named tags will instead be added directly to the JSON.  `named_tags` now adds key value pairs to object instead of nesting.  
+- NR Integration: Conflicts between `named_tags` and existing tags are logged to `named_tag_conflicts` key.
+- NR Integration: Adds a quick and hacky Dockerfile and Docker Compose file to allow for testing changes locally.
 
 ## [4.16.1]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM ruby:3.4-alpine
+
+# TODO: This is a very quick and hacky Dockerfile 
+# to isolate this from my actual system. 
+# This can be expanded later to cover the use
+# cases for this particular project. 
+# TODO: The current CI tests leverage the ruby setup action 
+# in a matrix config. It may instead be useful to include
+# rbenv in this container then leverage the Docker container
+# in tests. This will allow the local dev and CI environments
+# to more easily converge. 
+# The matrix can then pass an env var to select the necessary ruby versions
+# for each test. 
+# For guidance see: https://docs.docker.com/guides/ruby/containerize/
+
+# NOTE: Install all the deps first
+# TODO: Some of these may not be necessary. 
+# Review. 
+RUN apk add --no-cache \
+    build-base \
+    gcc \
+    g++ \
+    make \
+    libc-dev \
+    linux-headers \
+    musl-dev
+
+WORKDIR /opt/app
+
+# NOTE: The initial copies and bundle install should be small as possible
+# This ensures that unless one of these files changes, a rebuild will not
+# trigger Docker cache invalidation for these layers. 
+COPY Gemfile /opt/app/
+COPY semantic_logger.gemspec /opt/app/
+# COPY Gemfile.lock /opt/app/Gemfile.lock
+COPY lib/semantic_logger/version.rb /opt/app/lib/semantic_logger/version.rb
+RUN gem install bundler && bundle install
+
+# NOTE: Copy the remainder of files into the container. 
+COPY . /opt/app/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+name: 'semanticlogger'
+services:
+  semanticlogger:
+    image: "slog"
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+    restart: unless-stopped
+    volumes:
+      - ./:/opt/app:cached
+    environment:
+      - MONGO_HOST=mongodb:27017
+  mongodb: 
+    image: mongo

--- a/lib/semantic_logger/appender/new_relic_logs.rb
+++ b/lib/semantic_logger/appender/new_relic_logs.rb
@@ -52,7 +52,7 @@ module SemanticLogger
           self.class.log_newrelic(json_message, level)
         rescue JSON::GeneratorError => e
           STDERR.puts("Failed to serialize log message to JSON: #{e.message}")
-          STDERR.puts("Problematic data could not be inspected")
+          STDERR.puts("Problematic data: #{message.inspect}")
         rescue StandardError => e
           STDERR.puts("Unexpected error while logging to New Relic: #{e.message}")
         end

--- a/lib/semantic_logger/appender/new_relic_logs.rb
+++ b/lib/semantic_logger/appender/new_relic_logs.rb
@@ -51,10 +51,10 @@ module SemanticLogger
           level = log.level.to_s.upcase       # Determine the log level
           self.class.log_newrelic(json_message, level)
         rescue JSON::GeneratorError => e
-          warn("Failed to serialize log message to JSON: #{e.message}")
-          warn("Problematic data could not be inspected")
+          STDERR.puts("Failed to serialize log message to JSON: #{e.message}")
+          STDERR.puts("Problematic data could not be inspected")
         rescue StandardError => e
-          warn("Unexpected error while logging to New Relic: #{e.message}")
+          STDERR.puts("Unexpected error while logging to New Relic: #{e.message}")
         end
         true
       end

--- a/lib/semantic_logger/appender/new_relic_logs.rb
+++ b/lib/semantic_logger/appender/new_relic_logs.rb
@@ -51,10 +51,10 @@ module SemanticLogger
           level = log.level.to_s.upcase       # Determine the log level
           self.class.log_newrelic(json_message, level)
         rescue JSON::GeneratorError => e
-          STDERR.puts("Failed to serialize log message to JSON: #{e.message}")
-          STDERR.puts("Problematic data: #{message.inspect}")
+          $stderr.puts("Failed to serialize log message to JSON: #{e.message}")
+          $stderr.puts("Problematic data: #{message.inspect}")
         rescue StandardError => e
-          STDERR.puts("Unexpected error while logging to New Relic: #{e.message}")
+          $stderr.puts("Unexpected error while logging to New Relic: #{e.message}")
         end
         true
       end

--- a/lib/semantic_logger/appender/new_relic_logs.rb
+++ b/lib/semantic_logger/appender/new_relic_logs.rb
@@ -45,12 +45,22 @@ module SemanticLogger
 
       # Send an error notification to New Relic
       def log(log)
-        self.class.log_newrelic(formatter.call(log, self).to_json, log.level.to_s.upcase)
+        begin
+          message = formatter.call(log, self) # Generate the structured log
+          json_message = message.to_json      # Convert the log to JSON
+          level = log.level.to_s.upcase       # Determine the log level
+          self.class.log_newrelic(json_message, level)
+        rescue JSON::GeneratorError => e
+          warn("Failed to serialize log message to JSON: #{e.message}")
+          warn("Problematic data could not be inspected")
+        rescue StandardError => e
+          warn("Unexpected error while logging to New Relic: #{e.message}")
+        end
         true
       end
 
-      def self.log_newrelic(message, level)
-        ::NewRelic::Agent.agent.log_event_aggregator.record(message, level)
+      def self.log_newrelic(json_message, level)
+        ::NewRelic::Agent.agent.log_event_aggregator.record(json_message, level)
       end
     end
   end

--- a/lib/semantic_logger/formatters/new_relic_logs.rb
+++ b/lib/semantic_logger/formatters/new_relic_logs.rb
@@ -40,7 +40,7 @@ module SemanticLogger
         hash = super(log, logger)
 
         result = {
-          **new_relic_metadata,
+          **newrelic_metadata,
           message:       hash[:message].to_s,
           tags:          hash[:tags] || [],
           metric:        hash[:metric],
@@ -108,16 +108,11 @@ module SemanticLogger
 
       private
 
-      def new_relic_metadata
-        {
-          trace: {
-            id: NewRelic::Agent::Tracer.current_trace_id
-          },
-          span: {
-            id: NewRelic::Agent::Tracer.current_span_id
-          },
-          **NewRelic::Agent.linking_metadata.transform_keys(&:to_sym)
-        }
+      # NOTE: This function will already include trace.id and span.id if they 
+      # are available so I believe the previous implementation of this is redundant
+      # https://rubydoc.info/gems/newrelic_rpm/NewRelic/Agent#linking_metadata-instance_method
+      def newrelic_metadata
+        NewRelic::Agent.linking_metadata.transform_keys(&:to_sym)
       end
     end
   end

--- a/lib/semantic_logger/formatters/new_relic_logs.rb
+++ b/lib/semantic_logger/formatters/new_relic_logs.rb
@@ -16,7 +16,7 @@ module SemanticLogger
   module Formatters
     # Formatter for reporting to NewRelic's Logger
     #
-    # Newrelic gracefully handles (and flattens) any JSON based logs
+    # New Relic gracefully handles (and flattens) any JSON-based logs
     # We construct the json and pass it to Newrelic for further processing.
     #
     # == Reference

--- a/lib/semantic_logger/formatters/new_relic_logs.rb
+++ b/lib/semantic_logger/formatters/new_relic_logs.rb
@@ -42,7 +42,7 @@ module SemanticLogger
         result = {
           **newrelic_metadata,
           message:       hash[:message].to_s,
-          tags:          hash[:tags] || [],
+          tags:          hash[:tags],
           metric:        hash[:metric],
           metric_amount: hash[:metric_amount],
           environment:   hash[:environment],

--- a/lib/semantic_logger/formatters/new_relic_logs.rb
+++ b/lib/semantic_logger/formatters/new_relic_logs.rb
@@ -17,7 +17,7 @@ module SemanticLogger
     # Formatter for reporting to NewRelic's Logger
     #
     # New Relic gracefully handles (and flattens) any JSON-based logs
-    # We construct the json and pass it to Newrelic for further processing.
+    # We construct the JSON and pass it to New Relic for further processing.
     #
     # == Reference
     # * Logging specification

--- a/test/appender/new_relic_logs_test.rb
+++ b/test/appender/new_relic_logs_test.rb
@@ -11,13 +11,19 @@ module Appender
         @message  = "AppenderNewRelicTest log message"
       end
 
+      # Stub method for New Relic log ingestion
       def log_newrelic_stub(message, level)
         @logged_message = message
         @logged_level = level
-        @hash = JSON.parse(@logged_message)
-        @message_hash = JSON.parse(@hash["message"])
       end
 
+      # Parse the logged JSON message for assertions
+      def parse_logged_message
+        @hash = JSON.parse(@logged_message) rescue nil
+        @message_hash = JSON.parse(@hash["message"]) if @hash && @hash["message"].is_a?(String) rescue nil
+      end
+
+      # Test for each log level
       SemanticLogger::Levels::LEVELS.each do |level|
         it "sends :#{level} notifications to New Relic" do
           NewRelic::Agent.agent.log_event_aggregator.stub(:record, method(:log_newrelic_stub)) do
@@ -26,15 +32,18 @@ module Appender
             end
           end
 
-          assert_equal @message, @message_hash["message"]
-          assert_equal ["test"], @message_hash["tags"]
-          assert_nil @message_hash["duration"]
-          assert @hash["thread.name"], @hash.inspect
+          parse_logged_message
+          refute_nil @hash, "Expected @hash to be parsed JSON"
+          assert_equal @message, @hash["message"]
+          assert_equal ["test"], @hash["tags"]
+          assert_nil @hash.dig("duration", "ms")
+          assert @hash.dig("thread", "name"), @hash.inspect
           assert_equal @logged_level, level.to_s.upcase
         end
       end
 
-      it "send notification to New Relic with custom attributes" do
+      # Test for custom attributes
+      it "sends notification to New Relic with custom attributes" do
         SemanticLogger::Appender::NewRelicLogs.stub(:log_newrelic, method(:log_newrelic_stub)) do
           SemanticLogger.tagged("test") do
             SemanticLogger.named_tagged(key1: 1, key2: "a") do
@@ -45,19 +54,64 @@ module Appender
           end
         end
 
-        assert @hash["thread.name"], @hash.inspect
+        parse_logged_message
+        refute_nil @hash, "Expected @hash to be parsed JSON"
+        assert_equal @message, @hash["message"]
+        assert_equal ["test"], @hash["tags"]
+        assert @hash.dig("duration", "ms"), "Expected duration to be logged"
+        assert_equal 1, @hash["key1"]
+        assert_equal "a", @hash["key2"]
+        assert payload = @hash["payload"], @hash.inspect
+        assert_equal 4, payload["key3"]
+      end
 
-        assert params = @message_hash, hash
-        assert_equal @message, params["message"]
-        assert params["duration"], params
-        assert_equal ["test"], params["tags"], params
+      # Test for JSON serialization errors
+      it "handles JSON serialization errors gracefully" do
+        unserializable_object = Object.new
+        def unserializable_object.to_json(*_args)
+          raise JSON::GeneratorError, "Test serialization failure"
+        end
 
-        assert named_tags = params["named_tags"], params
-        assert_equal 1, named_tags["key1"], named_tags
-        assert_equal "a", named_tags["key2"], named_tags
+        log = SemanticLogger::Log.new("TestLogger", :info)
+        log.payload = unserializable_object
 
-        assert payload = params["payload"], params
-        assert_equal 4, payload["key3"], payload
+        assert_output(/Failed to serialize log message/) do
+          @appender.log(log)
+        end
+
+        assert_output(/Problematic data: /) do
+          @appender.log(log)
+        end
+      end
+
+      # Test for large payloads
+      it "handles large payloads gracefully" do
+        large_payload = { data: "a" * 10_000 }
+        log = SemanticLogger::Log.new("TestLogger", :info)
+        log.payload = large_payload
+
+        NewRelic::Agent.agent.log_event_aggregator.stub(:record, method(:log_newrelic_stub)) do
+          @appender.log(log)
+        end
+
+        parse_logged_message
+        refute_nil @hash, "Expected @hash to be parsed JSON"
+        assert_equal large_payload[:data], @hash.dig("payload", "data")
+      end
+
+      # Test for deeply nested payloads
+      it "handles deeply nested payloads gracefully" do
+        nested_payload = { level1: { level2: { level3: { level4: "deep_value" } } } }
+        log = SemanticLogger::Log.new("TestLogger", :info)
+        log.payload = nested_payload
+
+        NewRelic::Agent.agent.log_event_aggregator.stub(:record, method(:log_newrelic_stub)) do
+          @appender.log(log)
+        end
+
+        parse_logged_message
+        refute_nil @hash, "Expected @hash to be parsed JSON"
+        assert_equal "deep_value", @hash.dig("payload", "level1", "level2", "level3", "level4")
       end
     end
   end

--- a/test/formatters/new_relic_logs_test.rb
+++ b/test/formatters/new_relic_logs_test.rb
@@ -37,35 +37,76 @@ module SemanticLogger
           JSON.parse(formatted_log[:message]) if formatted_log[:message].is_a?(String)
         end
 
-        describe "metadata" do
-          it "includes trace.id and span.id if present" do
-            NewRelic::Agent.stub(:linking_metadata, { "trace.id" => "trace123", "span.id" => "span456" }) do
-              result = formatted_log
-              assert_equal "trace123", result[:'trace.id']
-              assert_equal "span456", result[:'span.id']
-            end
-          end
-        
-          it "omits trace.id and span.id if absent" do
-            NewRelic::Agent.stub(:linking_metadata, {}) do
-              result = formatted_log
-              refute result.key?(:'trace.id')
-              refute result.key?(:'span.id')
-            end
-          end
-        end
-
         describe "duration" do
-          it "includes duration and human-readable format" do
-            log.duration = 1234.567
+          it "logs long duration" do
+            log.duration = 1_000_000.34567
             result = formatted_log
-            assert_equal 1234.567, result.dig(:duration, :ms)
-            assert_equal "1.235s", result.dig(:duration, :human)
+        
+            assert_equal 1_000_000.34567, result.dig(:duration, :ms)
+            assert_equal "16m 40s", result.dig(:duration, :human)
+          end
+
+          it "logs short duration" do
+            log.duration = 1.34567
+            result = formatted_log
+          
+            # Expected human-readable duration based on precision
+            expected_human_duration = SemanticLogger::Formatters::Base::PRECISION == 3 ? "1.346ms" : "1.346ms"
+          
+            # Verify the raw duration in milliseconds
+            assert_equal 1.34567, result.dig(:duration, :ms)
+          
+            # Verify the human-readable duration format
+            assert_equal expected_human_duration, result.dig(:duration, :human)
           end
 
           it "omits duration if not set" do
             result = formatted_log
             refute result.key?(:duration)
+          end
+        end
+
+        describe "name" do
+          it "logs name" do
+            result = formatted_log
+            assert_equal "NewRelicLogsTest", result.dig(:logger, :name)
+          end
+        end
+        
+        describe "message" do
+          it "logs message" do
+            log.message = "Hello World"
+            result = formatted_log
+            assert_equal "Hello World", result[:message]
+          end
+        
+          it "keeps empty message" do
+            log.message = ""
+            result = formatted_log
+            assert_equal "", result[:message]
+          end
+        end
+
+        describe "payload" do
+          it "logs hash payload" do
+            log.payload = {first: 1, second: 2, third: 3}
+            result = formatted_log
+            assert_equal(
+              {first: 1, second: 2, third: 3},
+              result[:payload]
+            )
+          end
+        
+          it "skips nil payload" do
+            log.payload = nil
+            result = formatted_log
+            refute result.key?(:payload)
+          end
+        
+          it "skips empty payload" do
+            log.payload = {}
+            result = formatted_log
+            refute result.key?(:payload)
           end
         end
 
@@ -91,6 +132,12 @@ module SemanticLogger
         end
 
         describe "exceptions" do
+          it "skips nil exception" do
+            refute formatted_log.dig(:error, :message)
+            refute formatted_log.dig(:error, :class)
+            refute formatted_log.dig(:error, :stack)
+          end
+          
           it "logs exception details" do
             raise "Test Exception" rescue log.exception = $!
             result = formatted_log
@@ -118,6 +165,24 @@ module SemanticLogger
             result = formatted_log
             refute result.key?(:payload)
             refute result.key?(:tags)
+          end
+        end
+
+        describe "metadata" do
+          it "includes trace.id and span.id if present" do
+            NewRelic::Agent.stub(:linking_metadata, { "trace.id" => "trace123", "span.id" => "span456" }) do
+              result = formatted_log
+              assert_equal "trace123", result[:'trace.id']
+              assert_equal "span456", result[:'span.id']
+            end
+          end
+        
+          it "omits trace.id and span.id if absent" do
+            NewRelic::Agent.stub(:linking_metadata, {}) do
+              result = formatted_log
+              refute result.key?(:'trace.id')
+              refute result.key?(:'span.id')
+            end
           end
         end
       end

--- a/test/formatters/new_relic_logs_test.rb
+++ b/test/formatters/new_relic_logs_test.rb
@@ -28,171 +28,96 @@ module SemanticLogger
           log
         end
 
-        let(:expected_time) do
-          1_484_382_725_375
-        end
-
-        let(:set_exception) do
-          raise "Oh no"
-        rescue Exception => e
-          log.exception = e
-        end
-
-        let(:expected_exception_backtrace) do
-          log.exception.backtrace.join("\n")
-        end
-
-        let(:backtrace) do
-          [
-            "test/formatters/default_test.rb:99:in `block (2 levels) in <class:DefaultTest>'",
-            "gems/ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/spec.rb:247:in `instance_eval'",
-            "gems/ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/spec.rb:247:in `block (2 levels) in let'",
-            "gems/ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/spec.rb:247:in `fetch'",
-            "ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/spec.rb:247:in `block in let'",
-            "test/formatters/default_test.rb:65:in `block (3 levels) in <class:DefaultTest>'",
-            "ruby-2.3.3/gems/minitest-5.10.1/lib/minitest/test.rb:105:in `block (3 levels) in run'"
-          ]
-        end
-
         let(:formatted_log) do
           formatter = appender.formatter
           formatter.call(log, appender.logger)
         end
-
+        
         let(:message_hash) do
-          JSON.parse(formatted_log[:message])
+          JSON.parse(formatted_log[:message]) if formatted_log[:message].is_a?(String)
         end
 
-        describe "time" do
-          it "logs time" do
-            assert_equal expected_time, formatted_log[:timestamp]
+        describe "metadata" do
+          it "includes trace.id and span.id if present" do
+            NewRelic::Agent.stub(:linking_metadata, { "trace.id" => "trace123", "span.id" => "span456" }) do
+              result = formatted_log
+              assert_equal "trace123", result[:'trace.id']
+              assert_equal "span456", result[:'span.id']
+            end
           end
-        end
-
-        describe "level" do
-          it "logs long name" do
-            assert_equal "DEBUG", formatted_log[:"log.level"]
-          end
-        end
-
-        describe "process_info" do
-          it "logs thread name" do
-            assert_equal Thread.current.name, formatted_log[:"thread.name"]
-          end
-
-          it "logs pid, thread name, and file name" do
-            set_exception
-            log.backtrace = backtrace
-            assert_equal Thread.current.name, formatted_log[:"thread.name"]
-            assert_equal "test/formatters/default_test.rb", formatted_log[:"file.name"]
-            assert_equal "99", formatted_log[:"line.number"]
-          end
-        end
-
-        describe "tags" do
-          it "logs tags" do
-            log.tags = %w[first second third]
-            assert_equal log.tags, message_hash["tags"]
-          end
-        end
-
-        describe "named_tags" do
-          it "logs named tags" do
-            log.named_tags = {first: 1, second: 2, third: 3}
-            assert_equal(
-              {"first" => 1, "second" => 2, "third" => 3},
-              message_hash["named_tags"]
-            )
+        
+          it "omits trace.id and span.id if absent" do
+            NewRelic::Agent.stub(:linking_metadata, {}) do
+              result = formatted_log
+              refute result.key?(:'trace.id')
+              refute result.key?(:'span.id')
+            end
           end
         end
 
         describe "duration" do
-          it "logs long duration" do
-            log.duration = 1_000_000.34567
-            assert_equal log.duration, message_hash["duration"]
+          it "includes duration and human-readable format" do
+            log.duration = 1234.567
+            result = formatted_log
+            assert_equal 1234.567, result.dig(:duration, :ms)
+            assert_equal "1.235s", result.dig(:duration, :human)
           end
 
-          it "logs short duration" do
-            log.duration = 1.34567
-            duration     = SemanticLogger::Formatters::Base::PRECISION == 3 ? "1ms" : "1.346ms"
-
-            assert_equal duration, message_hash["duration_human"]
-            assert_equal log.duration, message_hash["duration"]
-          end
-        end
-
-        describe "name" do
-          it "logs name" do
-            assert_equal "NewRelicLogsTest", formatted_log[:"logger.name"]
+          it "omits duration if not set" do
+            result = formatted_log
+            refute result.key?(:duration)
           end
         end
 
-        describe "message" do
-          it "logs message" do
+        describe "tags and named_tags" do
+          it "logs tags" do
+            log.tags = %w[first second third]
+            assert_equal %w[first second third], formatted_log[:tags]
+          end
+
+          it "logs named tags without conflicts" do
+            log.named_tags = { first: 1, second: 2 }
+            result = formatted_log
+            assert_equal 1, result[:first]
+            assert_equal 2, result[:second]
+            refute result.key?(:named_tag_conflicts)
+          end
+
+          it "logs named tag conflicts" do
+            log.named_tags = { message: "conflict" }
+            result = formatted_log
+            assert_includes result[:named_tag_conflicts], :message
+          end
+        end
+
+        describe "exceptions" do
+          it "logs exception details" do
+            raise "Test Exception" rescue log.exception = $!
+            result = formatted_log
+            assert_equal "Test Exception", result.dig(:error, :message)
+            assert_equal "RuntimeError", result.dig(:error, :class)
+            assert result.dig(:error, :stack).is_a?(String)
+          end
+
+          it "omits exception if not set" do
+            result = formatted_log
+            refute result.key?(:error)
+          end
+        end
+
+        describe "general structure" do
+          it "includes standard fields" do
             log.message = "Hello World"
-            assert_equal "Hello World", message_hash["message"]
+            result = formatted_log
+            assert_equal "Hello World", result[:message]
+            assert_equal "NewRelicLogsTest", result.dig(:logger, :name)
+            assert result[:timestamp].is_a?(Integer)
           end
 
-          it "keeps empty message" do
-            assert_equal "", message_hash["message"]
-          end
-        end
-
-        describe "payload" do
-          it "logs hash payload" do
-            log.payload = {first: 1, second: 2, third: 3}
-            assert_equal(
-              {"first" => 1, "second" => 2, "third" => 3},
-              message_hash["payload"]
-            )
-          end
-
-          it "skips nil payload" do
-            refute message_hash["payload"]
-          end
-
-          it "skips empty payload" do
-            log.payload = {}
-            refute message_hash["payload"]
-          end
-        end
-
-        describe "exception" do
-          it "skips nil exception" do
-            refute formatted_log[:"error.message"]
-            refute formatted_log[:"error.class"]
-            refute formatted_log[:"error.stack"]
-          end
-        end
-
-        describe "call" do
-          it "retuns all elements" do
-            log.tags       = %w[first second third]
-            log.named_tags = {first: 1, second: 2, third: 3}
-            log.duration   = 1.34567
-            log.message    = "Hello World"
-            log.payload    = {first: 1, second: 2, third: 3}
-            log.backtrace  = backtrace
-            set_exception
-            duration = SemanticLogger::Formatters::Base::PRECISION == 3 ? "1" : "1.346"
-
-            expected_hash = {
-              "entity.name":   "Entity Name",
-              "entity.type":   "SERVICE",
-              hostname:        "hostname",
-              message:         "{\"message\":\"Hello World\",\"tags\":[\"first\",\"second\",\"third\"],\"named_tags\":{\"first\":1,\"second\":2,\"third\":3},\"environment\":\"test\",\"application\":\"Semantic Logger\",\"payload\":{\"first\":1,\"second\":2,\"third\":3},\"duration\":1.34567,\"duration_human\":\"1.346ms\"}",
-              timestamp:       1_484_382_725_375,
-              "log.level":     "DEBUG",
-              "logger.name":   "NewRelicLogsTest",
-              "thread.name":   Thread.current.name,
-              "error.message": "Oh no",
-              "error.class":   "RuntimeError",
-              "error.stack":   expected_exception_backtrace,
-              "file.name":     "test/formatters/default_test.rb",
-              "line.number":   "99"
-            }
-
-            assert_equal expected_hash, formatted_log
+          it "omits nil or empty fields" do
+            result = formatted_log
+            refute result.key?(:payload)
+            refute result.key?(:tags)
           end
         end
       end


### PR DESCRIPTION
### Issue # (if available)

https://github.com/reidmorrison/semantic_logger/issues/300

### Changelog

Changelog updated appropriately. 

Content below

```
- NR Integration: Ensures key/values are not nested under `messages`
- NR Integration: Ensures structures are built for all nested json (I.E build an actual object instead of doing `span.id` as the key)
- NR Integration: Named tags will instead be added directly to the JSON.  `named_tags` now adds key value pairs to object instead of nesting.  
- NR Integration: Conflicts between `named_tags` and existing tags are logged to `named_tag_conflicts` key.
- NR Integration: Adds a quick and hacky Dockerfile and Docker Compose file to allow for testing changes locally.
```

### Description of changes

This PR fixes the NR Log Formatter so that keys are no longer erroneously nested under the `message.` key as mentioned in the linked issue. 

This was initially [commented on in the original PR](https://github.com/reidmorrison/semantic_logger/pull/248/files#r1104979556) but was simply missed. 

- Ensures key/values are not nested under `messages`
- Ensures structures are built for all nested json (I.E build actual objects)
- Unnest named_tags. 
  - Named tags will instead be added directly to the JSON. 
  - Any conflicts with existing keys are logged to the `named_tag_conflicts` key so they are clearly visible and can be alerted on via NR. 
- Adds a quick and hacky Dockerfile and Docker Compose file to allow for testing changes locally.
  - This can be expanded later to unify the local development environment and the CI environment for easier testing. 

### Screenshots 

#### Before

![CleanShot 2024-12-31 at 14 10 24@2x](https://github.com/user-attachments/assets/e3a09e2b-a319-4920-9d73-ae8a7496d48f)

#### After 
![CleanShot 2024-12-31 at 14 09 03@2x](https://github.com/user-attachments/assets/511d21b5-f1ba-4adf-8aac-0aff9801788b)

### Other details

Newrelic documentation is often incredibly contradictory with things spread all over the place. 

Here they mention that the addition of a `logtype` value is _required_ to utilize any log parsing rules in their best practices guide

https://docs.newrelic.com/docs/logs/get-started/logging-best-practices/

>Add a logtype attribute to all the data you forward. The attribute is **required** to use our built-in parsing rules and can also be used to create custom parsing rules based on the data type. The logtype attribute is considered a well known attribute and is used in our quickstart dashboards for log summary information

They then contradict themselves in the Log Parsing docs saying that while this is suggested, it is not explicitly required. 

https://docs.newrelic.com/docs/logs/ui-data/parsing/

>To simplify the matching process, we recommend adding a [logtype](https://docs.newrelic.com/docs/logs/ui-data/parsing/#logtype) attribute to your logs. However, you are not limited to using logtype; one or more attributes can be used as matching criteria in the NRQL WHERE clause.

I can find no example for adding this via the Ruby APM Agent in their docs. I believe it may be possible to do so with the following configuration variable but I'm uncertain if this decoration will work with the SL gem. 

https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#application_logging-forwarding-custom_attributes

If we find that adding this at the APM level does not append this to the logs, another PR should likely be created to ensure it's possible to optionally set this value (Possibly with a default value like "logtype: semanticlogger" or similar). 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
