### PR TITLE
CI against Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, "3.0", 3.1, 3.2, 3.3]
+        ruby: [2.7, "3.0", 3.1, 3.2, 3.3, 3.4]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby

--- a/test/formatters/default_test.rb
+++ b/test/formatters/default_test.rb
@@ -146,7 +146,7 @@ module SemanticLogger
         describe "payload" do
           it "logs hash payload" do
             log.payload = {first: 1, second: 2, third: 3}
-            assert_equal "-- {:first=>1, :second=>2, :third=>3}", formatter.payload
+            assert_equal "-- #{{:first=>1, :second=>2, :third=>3}}", formatter.payload
           end
 
           it "skips nil payload" do
@@ -184,7 +184,7 @@ module SemanticLogger
             log.backtrace  = backtrace
             set_exception
             duration = SemanticLogger::Formatters::Base::PRECISION == 3 ? "1" : "1.346"
-            str      = "#{expected_time} D [#{$$}:#{Thread.current.name} default_test.rb:99] [first] [second] [third] {first: 1, second: 2, third: 3} (#{duration}ms) DefaultTest -- Hello World -- {:first=>1, :second=>2, :third=>3} -- Exception: RuntimeError: Oh no\n"
+            str      = "#{expected_time} D [#{$$}:#{Thread.current.name} default_test.rb:99] [first] [second] [third] {first: 1, second: 2, third: 3} (#{duration}ms) DefaultTest -- Hello World -- #{{:first=>1, :second=>2, :third=>3}} -- Exception: RuntimeError: Oh no\n"
             assert_equal str, formatter.call(log, nil).lines.first
           end
         end


### PR DESCRIPTION
### Issue # (if available)

### Changelog


### Description of changes


This PR adds Ruby 3.4 to the CI matrix to confirm Semantic Logger works with Ruby 3.4.

In Ruby 3.4,  the result of `Hash.inspect` has changed. So I updated some specs to wrap hash with `#{}` to work both 3.4 and older.
Ref: https://bugs.ruby-lang.org/issues/20433