### PR TITLE
Fix the experimental formatter so its payload method coerces values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix the experimental OpenTelemetry formatter so its payload method coerces values.
+  Ensures every attribute value is OTLP‑compatible.
+
 ## [4.17.0]
 
 - Correct `source_code_uri` URL


### PR DESCRIPTION
Ensures every attribute value is OTLP‑compatible. Hashes become a JSON string, `nil` is dropped, arrays become arrays of strings/numbers/bools.

### Description of changes

This PR updates the `OpenTelemetry` formatter to ensure that all values in the log payload are compatible with the OpenTelemetry Protocol (OTLP) specification for log attributes.

The changes introduce methods, to recursively sanitize the payload hash.

The coercion rules are as follows:
-   Primitive types (`String`, `Integer`, `Float`, `Boolean`) are passed through unchanged.
-   `nil` values are dropped from the payload.
-   `Array` values are sanitized to ensure they only contain OTLP-compatible scalar types.
-   `Hash` values are converted into a JSON string.
-   All other object types are converted to their string representation.

This prevents potential errors when exporting logs to an OpenTelemetry collector by guaranteeing that all attributes adhere to the expected format. Example errors:

```
OpenTelemetry error: invalid log record attribute value type NilClass for key 'cached' on record: 
'{"host"=>"...", "application"=>"Semantic Logger", "environment"=>"staging", "pid"=>25, "thread"=>"10400", "duration_ms"=>0.7280009999813046, "duration"=>"0.728ms", "name"=>"ActiveRecord"}'

OpenTelemetry error: invalid log record attribute value type Hash for key 'binds' on record: 
'{"host"=>"...", "application"=>"Semantic Logger", "environment"=>"staging", "pid"=>25, "thread"=>"10400", "duration_ms"=>4.9787300000025425, "duration"=>"4.979ms", "name"=>"ActiveRecord", "message"=>"ActiveRecord::InternalMetadata Load"}'

OpenTelemetry error: invalid log record attribute value type ActiveSupport::HashWithIndifferentAccess for key 'params' on record: 
'{"host"=>"...", "application"=>"Semantic Logger", "environment"=>"staging", "pid"=>34, "thread"=>"puma threadpool 003", "duration_ms"=>349.21533600008115, "duration"=>"349.2ms", "named_tags"=>{:request_id=>"929eb898-888f-48c6-a406-4079b0933cd5"}, "name"=>"SellersController", "message"=>"Completed #show"}'
  ```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
