### PR TITLE
Add child logger with instance named tags support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   Ensures every attribute value is OTLP‑compatible.
 - Fix missing trace.id/span.id in NewRelic logs
 - Fix opentelemetry-logs-sdk logger does not expose logger_provider, causing NoMethodError on flush/close.
+- Add `tagged` without a block to create loggers with instance tags (positional and/or named)
 
 ## [4.17.0]
 

--- a/TAG_MERGING.md
+++ b/TAG_MERGING.md
@@ -1,0 +1,287 @@
+# Tag Merging Behavior
+
+This document describes how tags are merged in SemanticLogger when using instance tags (child loggers) and thread tags (tagged blocks).
+
+## Concepts
+
+- **Instance tags**: Tags attached to a logger instance via `logger.tagged(...)` without a block. These are permanent for that logger instance.
+- **Thread tags**: Tags pushed to the thread for the duration of a `tagged { }` block. These are temporary and scoped to the block.
+- **Positional tags**: Array of string tags, e.g., `tagged('request-123', 'user-456')`
+- **Named tags**: Hash of key-value pairs, e.g., `tagged(user: 'alice', request_id: '123')`
+
+## Two Merge Points (Important)
+
+Tag merging happens at **two different points** with **different merge semantics**. Understanding this distinction is critical:
+
+### 1. Runtime Combination (base.rb)
+
+When a child logger calls `tagged { }` with a block, its instance tags are combined with the block's tags and pushed to thread context:
+
+```ruby
+# In base.rb:208-210
+combined_tags = instance_tags + tags                              # instance first, then block
+combined_named_tags = instance_named_tags.merge(named_tags)       # block wins on conflicts
+```
+
+**Purpose**: Convert instance tags to thread tags for the block duration.
+
+**Merge order**: Block/thread tags override instance tags. This makes sense because the block provides more specific, immediate context.
+
+### 2. Output Formatting (formatters)
+
+When a log is rendered, formatters combine thread tags and instance tags for display:
+
+```ruby
+# In formatters (default.rb, raw.rb, etc.)
+tags + instance_tags                                              # thread first, then instance
+named_tags.merge(instance_named_tags)                             # instance wins on conflicts
+```
+
+**Purpose**: Render both tag sources in the final output.
+
+**Merge order**: Instance tags override thread tags. Instance tags represent the logger's permanent identity and take precedence over transient thread context.
+
+### Why They Differ
+
+These operations serve different purposes:
+
+| Aspect | Runtime (base.rb) | Output (formatters) |
+|--------|-------------------|---------------------|
+| When | During `tagged { }` block entry | During log rendering |
+| What | Combines tags before pushing to thread | Combines tags for display |
+| Winner on conflict | Block tags (more specific context) | Instance tags (permanent identity) |
+
+The runtime merge in base.rb does **not** affect formatter output directly. The formatter always receives separate `log.tags` (thread) and `log.instance_tags` (instance) and combines them independently.
+
+---
+
+## Index
+
+1. [Root Logger Cases](#1-root-logger-cases)
+   - 1.1 [No context](#11-no-context)
+   - 1.2 [With thread tags](#12-with-thread-tags)
+
+2. [Child Logger Cases (No Thread Context)](#2-child-logger-cases-no-thread-context)
+   - 2.1 [With instance tags](#21-with-instance-tags)
+
+3. [Child Logger with Thread Context (Independent)](#3-child-logger-with-thread-context-independent)
+   - 3.1 [Instance tags + thread tags (via root)](#31-instance-tags--thread-tags-via-root)
+
+4. [Child Logger Inside Own Tagged Block](#4-child-logger-inside-own-tagged-block)
+   - 4.1 [Instance tags + own block tags](#41-instance-tags--own-block-tags)
+
+5. [Nested Child Loggers](#5-nested-child-loggers)
+   - 5.1 [Child of child logger](#51-child-of-child-logger)
+   - 5.2 [Child logger inside another child's tagged block](#52-child-logger-inside-another-childs-tagged-block)
+
+6. [Edge Cases](#6-edge-cases)
+   - 6.1 [Named tag key conflicts](#61-named-tag-key-conflicts)
+
+---
+
+## 1. Root Logger Cases
+
+### 1.1 No context
+
+```ruby
+logger = SemanticLogger['MyClass']
+logger.info('Hello')
+```
+
+| Field | Value |
+|-------|-------|
+| `log.tags` | `[]` |
+| `log.named_tags` | `{}` |
+| `log.instance_tags` | `[]` |
+| `log.instance_named_tags` | `{}` |
+| **Formatted output** | (no tags) |
+
+### 1.2 With thread tags
+
+```ruby
+logger = SemanticLogger['MyClass']
+logger.tagged('request-123', user: 'alice') do
+  logger.info('Hello')
+end
+```
+
+| Field | Value |
+|-------|-------|
+| `log.tags` | `['request-123']` |
+| `log.named_tags` | `{user: 'alice'}` |
+| `log.instance_tags` | `[]` |
+| `log.instance_named_tags` | `{}` |
+| **Formatted output** | `[request-123] {user: alice}` |
+
+---
+
+## 2. Child Logger Cases (No Thread Context)
+
+### 2.1 With instance tags
+
+```ruby
+logger = SemanticLogger['MyClass']
+child = logger.tagged('service-a', version: '2.0')
+child.info('Hello')
+```
+
+| Field | Value |
+|-------|-------|
+| `log.tags` | `[]` |
+| `log.named_tags` | `{}` |
+| `log.instance_tags` | `['service-a']` |
+| `log.instance_named_tags` | `{version: '2.0'}` |
+| **Formatted output** | `[service-a] {version: 2.0}` |
+
+---
+
+## 3. Child Logger with Thread Context (Independent)
+
+These cases use a child logger inside a tagged block from a **different** logger (typically root). The instance tags and thread tags are independent.
+
+### 3.1 Instance tags + thread tags (via root)
+
+```ruby
+logger = SemanticLogger['MyClass']
+child = logger.tagged('instance-pos', service: 'api')
+
+logger.tagged('thread-pos', request_id: '123') do
+  child.info('Hello')
+end
+```
+
+| Field | Value |
+|-------|-------|
+| `log.tags` | `['thread-pos']` |
+| `log.named_tags` | `{request_id: '123'}` |
+| `log.instance_tags` | `['instance-pos']` |
+| `log.instance_named_tags` | `{service: 'api'}` |
+| **Formatted output** | `[thread-pos] [instance-pos] {request_id: 123, service: api}` |
+
+Thread positional tags appear first, then instance positional tags. Named tags are merged as `thread_named_tags.merge(instance_named_tags)`, with instance named tags overriding thread named tags on conflict.
+
+---
+
+## 4. Child Logger Inside Own Tagged Block
+
+When a child logger calls `tagged { }` on itself, its instance tags are pushed to the thread for the duration of the block. This results in **expected duplication** in the log output.
+
+### 4.1 Instance tags + own block tags
+
+```ruby
+logger = SemanticLogger['MyClass']
+child = logger.tagged('instance-pos', service: 'api')
+
+child.tagged('block-pos', request_id: '123') do
+  child.info('Hello')
+end
+```
+
+| Field | Value |
+|-------|-------|
+| `log.tags` | `['instance-pos', 'block-pos']` |
+| `log.named_tags` | `{service: 'api', request_id: '123'}` |
+| `log.instance_tags` | `['instance-pos']` |
+| `log.instance_named_tags` | `{service: 'api'}` |
+| **Formatted output** | `[instance-pos] [block-pos] [instance-pos] {service: api, request_id: 123, service: api}` |
+
+The instance tags appear twice: once from the thread (combined by the tagged block) and once from the instance. This is expected behavior.
+
+**Recommendation**: Inside the block, use a logger without instance tags if you want to avoid duplication:
+
+```ruby
+child.tagged('block-pos', request_id: '123') do
+  logger.info('Hello')  # Use root logger, not child
+end
+```
+
+---
+
+## 5. Nested Child Loggers
+
+### 5.1 Child of child logger
+
+```ruby
+logger = SemanticLogger['MyClass']
+child1 = logger.tagged('level-1')
+child2 = child1.tagged('level-2')
+child2.info('Hello')
+```
+
+| Field | Value |
+|-------|-------|
+| `log.tags` | `[]` |
+| `log.named_tags` | `{}` |
+| `log.instance_tags` | `['level-1', 'level-2']` |
+| `log.instance_named_tags` | `{}` |
+| **Formatted output** | `[level-1] [level-2]` |
+
+Instance tags accumulate through the child chain.
+
+### 5.2 Child logger inside another child's tagged block
+
+```ruby
+logger = SemanticLogger['MyClass']
+child1 = logger.tagged('child1-tag', service: 'api')
+child2 = logger.tagged('child2-tag', component: 'worker')
+
+child1.tagged('block-tag', request_id: '123') do
+  child2.info('Hello')  # Different child logger used inside block
+end
+```
+
+| Field | Value |
+|-------|-------|
+| `log.tags` | `['child1-tag', 'block-tag']` |
+| `log.named_tags` | `{service: 'api', request_id: '123'}` |
+| `log.instance_tags` | `['child2-tag']` |
+| `log.instance_named_tags` | `{component: 'worker'}` |
+| **Formatted output** | `[child1-tag] [block-tag] [child2-tag] {service: api, request_id: 123, component: worker}` |
+
+The thread tags come from child1's tagged block (which includes child1's instance tags). The instance tags come from child2.
+
+---
+
+## 6. Edge Cases
+
+### 6.1 Named tag key conflicts
+
+When the same key exists in both instance_named_tags and thread named_tags:
+
+```ruby
+logger = SemanticLogger['MyClass']
+child = logger.tagged(user: 'instance-user')
+
+child.tagged(user: 'block-user') do
+  child.info('Hello')
+end
+```
+
+| Field | Value |
+|-------|-------|
+| `log.named_tags` | `{user: 'block-user'}` |
+| `log.instance_named_tags` | `{user: 'instance-user'}` |
+
+**Question**: Which value wins in the formatted output?
+
+In `base.rb`, the runtime combination is: `instance_named_tags.merge(named_tags)` — so **block tags win** (for pushing to thread context).
+
+In formatters, the output combination is: `named_tags.merge(instance_named_tags)` — so **instance tags win** (permanent identity takes precedence over transient context).
+
+---
+
+## Summary Table
+
+| Scenario | Thread Tags Source | Instance Tags Source | Duplication? |
+|----------|-------------------|---------------------|--------------|
+| Root + tagged block | Block args | None | No |
+| Child + no block | None | Child creation args | No |
+| Child + root's block | Root's block | Child creation args | No |
+| Child + own block | Child instance + block args | Child creation args | Yes (expected) |
+| Child of child | None | Accumulated from chain | No |
+
+---
+
+## Open Questions
+
+None at this time.

--- a/docs/api.md
+++ b/docs/api.md
@@ -633,4 +633,39 @@ Or, when using a Gemfile:
 gem "semantic_logger", require: "semantic_logger/sync"
 ~~~
 
+### Instance Tagged Logger
+
+It is possible to create loggers with pre-set instance tags using `tagged` without a block.
+Any log message emitted by a logger with pre-set instance tags will include these tags along with the message data.
+
+~~~ruby
+logger = SemanticLogger["MyClass"]
+
+# Named tags
+tagged_logger = logger.tagged(user: "alice", request_id: "123")
+tagged_logger.info("Some message")  # includes user and request_id
+
+# Positional tags
+tagged_logger = logger.tagged("tag1", "tag2")
+tagged_logger.info("Some message")  # includes tag1 and tag2
+
+# Both positional and named tags
+tagged_logger = logger.tagged("request", user: "alice")
+tagged_logger.info("Some message")  # includes "request" tag and user named tag
+
+# Chaining
+child_logger = logger.tagged(user: "alice").tagged(request_id: "123")
+child_logger.info("Some message")  # includes both user and request_id
+~~~
+
+When calling `tagged` with a block on an instance-tagged logger, the instance tags are pushed to the thread for the duration of the block:
+
+~~~ruby
+tagged_logger = logger.tagged("instance_tag", user: "alice")
+
+tagged_logger.tagged("block_tag", request_id: "123") do
+  logger.info("Hello")  # tags: [instance_tag, block_tag], named_tags: {user: alice, request_id: 123}
+end
+~~~
+
 ### [Next: Testing ==>](testing.html)

--- a/lib/semantic_logger/base.rb
+++ b/lib/semantic_logger/base.rb
@@ -6,8 +6,18 @@
 #
 module SemanticLogger
   class Base
+    # Creates a copy of an existing logger.
+    # This method can be overridden by subclasses to provide a specialized implementation.
+    # `child` logger uses this method.
+    def self.copy(instance)
+      raise ArgumentError, "Cannot copy instances different from #{self}" if instance.class != self
+
+      instance.dup
+    end
+
     # Class name to be logged
     attr_accessor :name, :filter
+    attr_reader :instance_named_tags, :instance_tags
 
     # Set the logging level for this logger
     #
@@ -130,7 +140,7 @@ module SemanticLogger
                   payload: nil,
                   metric: nil,
                   metric_amount: nil)
-      log = Log.new(name, level)
+      log = Log.new(name, level, nil, instance_tags, instance_named_tags)
       return false unless meets_log_level?(log)
 
       backtrace =
@@ -185,20 +195,42 @@ module SemanticLogger
     #   to:
     #     `logger.tagged('first', 'more', 'other')`
     # - For better performance with clean tags, see `SemanticLogger.tagged`.
-    def tagged(*tags)
-      block = -> { yield(self) }
-      # Allow named tags to be passed into the logger
-      # Rails::Rack::Logger passes logs as an array with a single argument
-      if tags.size == 1 && !tags.first.is_a?(Array)
-        tag = tags[0]
-        return yield if tag.nil? || tag == ""
+    def tagged(*tags, **named_tags, &block)
+      # Without a block: return a child logger with instance tags
+      unless block
+        return self if tags.empty? && named_tags.empty?
 
-        return tag.is_a?(Hash) ? SemanticLogger.named_tagged(tag, &block) : SemanticLogger.fast_tag(tag.to_s, &block)
+        return child(*tags, **named_tags)
       end
 
+      # With a block: push instance tags + block tags to thread for duration of block
+      # Combine instance tags with block tags
+      combined_tags = instance_tags.empty? ? tags : instance_tags + tags
+      # Combine instance named tags with block named tags
+      combined_named_tags = instance_named_tags.empty? ? named_tags : instance_named_tags.merge(named_tags)
+
+      # Wrap yielder with named_tagged if there are combined named tags
+      yielder = -> { yield(self) }
+      if combined_named_tags.any?
+        inner_yielder = yielder
+        yielder = -> { SemanticLogger.named_tagged(combined_named_tags, &inner_yielder) }
+      end
+
+      # Handle positional tags
+      # Allow named tags to be passed into the logger
+      # Rails::Rack::Logger passes logs as an array with a single argument
+      if combined_tags.size == 1 && !combined_tags.first.is_a?(Array)
+        tag = combined_tags[0]
+        return yielder.call if tag.nil? || tag == ""
+
+        return SemanticLogger.fast_tag(tag.to_s, &yielder)
+      end
+
+      return yielder.call if combined_tags.empty?
+
       # Need to flatten and reject empties to support calls from Rails 4
-      new_tags = tags.flatten.collect(&:to_s).reject(&:empty?)
-      SemanticLogger.tagged(*new_tags, &block)
+      new_tags = combined_tags.flatten.collect(&:to_s).reject(&:empty?)
+      SemanticLogger.tagged(*new_tags, &yielder)
     end
 
     # :nodoc:
@@ -250,7 +282,29 @@ module SemanticLogger
       meets_log_level?(log) && !filtered?(log)
     end
 
+    protected
+
+    def instance_tags=(tags)
+      # Prevent accidental mutation of log tags
+      @instance_tags = tags.dup.freeze
+    end
+
+    def instance_named_tags=(named_tags)
+      # Prevent accidental mutation of log named tags
+      @instance_named_tags = named_tags.dup.freeze
+    end
+
     private
+
+    # Creates a new logger with the given instance tags
+    def child(*tags, **named_tags)
+      new_tags = instance_tags + tags
+      new_named_tags = instance_named_tags.merge(named_tags)
+      new_logger = self.class.copy(self)
+      new_logger.instance_tags = new_tags
+      new_logger.instance_named_tags = new_named_tags
+      new_logger
+    end
 
     # Initializer for Abstract Class SemanticLogger::Base
     #
@@ -275,7 +329,7 @@ module SemanticLogger
     #          (/\AExclude/ =~ log.message).nil?
     #        end
     #      end
-    def initialize(klass, level = nil, filter = nil)
+    def initialize(klass, level = nil, filter = nil, instance_tags = [], instance_named_tags = {})
       # Support filtering all messages to this logger instance.
       unless filter.nil? || filter.is_a?(Regexp) || filter.is_a?(Proc) || filter.respond_to?(:call)
         raise ":filter must be a Regexp, Proc, or implement :call"
@@ -290,6 +344,8 @@ module SemanticLogger
       else
         self.level = level
       end
+      self.instance_tags = instance_tags
+      self.instance_named_tags = instance_named_tags
     end
 
     # Return the level index for fast comparisons
@@ -325,7 +381,7 @@ module SemanticLogger
         payload = nil
       end
 
-      log = Log.new(name, level, index)
+      log = Log.new(name, level, index, instance_tags, instance_named_tags)
       should_log =
         if exception.nil? && payload.nil? && message.is_a?(Hash)
           # All arguments as a hash in the message.
@@ -376,7 +432,7 @@ module SemanticLogger
         exception = e
       ensure
         # Must use ensure block otherwise a `return` in the yield above will skip the log entry
-        log = Log.new(name, level, index)
+        log = Log.new(name, level, index, instance_tags, instance_named_tags)
         exception ||= params[:exception]
         message   = params[:message] if params[:message]
         duration  =
@@ -424,7 +480,7 @@ module SemanticLogger
       rescue Exception => e
         exception = e
       ensure
-        log = Log.new(name, level, index)
+        log = Log.new(name, level, index, instance_tags, instance_named_tags)
         # May return false due to elastic logging
         should_log = log.assign(
           message:            message,

--- a/lib/semantic_logger/formatters/color.rb
+++ b/lib/semantic_logger/formatters/color.rb
@@ -85,16 +85,39 @@ module SemanticLogger
       end
 
       def tags
-        "[#{color}#{log.tags.join("#{color_map.clear}] [#{color}")}#{color_map.clear}]" if log.tags && !log.tags.empty?
+        instance_tags = log.instance_tags
+        tags          = log.tags
+        has_instance  = instance_tags && !instance_tags.empty?
+        has_tags      = tags && !tags.empty?
+
+        case
+        when has_instance && has_tags then combined = tags + instance_tags
+        when has_instance             then combined = instance_tags
+        when has_tags                 then combined = tags
+        else                               combined = nil
+        end
+        return nil unless combined
+
+        "[#{color}#{combined.join("#{color_map.clear}] [#{color}")}#{color_map.clear}]"
       end
 
       # Named Tags
       def named_tags
-        named_tags = log.named_tags
-        return if named_tags.nil? || named_tags.empty?
+        named_tags          = log.named_tags
+        instance_named_tags = log.instance_named_tags
+        has_named           = named_tags && !named_tags.empty?
+        has_instance        = instance_named_tags && !instance_named_tags.empty?
+
+        case
+        when has_named && has_instance then merged = named_tags.merge(instance_named_tags)
+        when has_named                 then merged = named_tags
+        when has_instance              then merged = instance_named_tags
+        else                                merged = nil
+        end
+        return nil unless merged
 
         list = []
-        named_tags.each_pair { |name, value| list << "#{color}#{name}: #{value}#{color_map.clear}" }
+        merged.each_pair { |name, value| list << "#{color}#{name}: #{value}#{color_map.clear}" }
         "{#{list.join(', ')}}"
       end
 

--- a/lib/semantic_logger/formatters/default.rb
+++ b/lib/semantic_logger/formatters/default.rb
@@ -32,16 +32,39 @@ module SemanticLogger
 
       # Tags
       def tags
-        "[#{log.tags.join('] [')}]" if log.tags && !log.tags.empty?
+        instance_tags = log.instance_tags
+        tags          = log.tags
+        has_instance  = instance_tags && !instance_tags.empty?
+        has_tags      = tags && !tags.empty?
+
+        case
+        when has_instance && has_tags then combined = tags + instance_tags
+        when has_instance             then combined = instance_tags
+        when has_tags                 then combined = tags
+        else                               combined = nil
+        end
+        return nil unless combined
+
+        "[#{combined.join('] [')}]"
       end
 
       # Named Tags
       def named_tags
-        named_tags = log.named_tags
-        return if named_tags.nil? || named_tags.empty?
+        named_tags          = log.named_tags
+        instance_named_tags = log.instance_named_tags
+        has_named           = named_tags && !named_tags.empty?
+        has_instance        = instance_named_tags && !instance_named_tags.empty?
+
+        case
+        when has_named && has_instance then merged = named_tags.merge(instance_named_tags)
+        when has_named                 then merged = named_tags
+        when has_instance              then merged = instance_named_tags
+        else                                merged = nil
+        end
+        return nil unless merged
 
         list = []
-        named_tags.each_pair { |name, value| list << "#{name}: #{value}" }
+        merged.each_pair { |name, value| list << "#{name}: #{value}" }
         "{#{list.join(', ')}}"
       end
 

--- a/lib/semantic_logger/formatters/loki.rb
+++ b/lib/semantic_logger/formatters/loki.rb
@@ -70,11 +70,22 @@ module SemanticLogger
       end
 
       def tags
-        stream[:stream][:tags] = log.tags if log.tags.respond_to?(:empty?) && !log.tags.empty?
+        instance_tags = log.instance_tags
+        tags          = log.tags
+        has_instance  = instance_tags.respond_to?(:empty?) && !instance_tags.empty?
+        has_tags      = tags.respond_to?(:empty?) && !tags.empty?
+
+        case
+        when has_instance && has_tags then stream[:stream][:tags] = tags + instance_tags
+        when has_instance             then stream[:stream][:tags] = instance_tags
+        when has_tags                 then stream[:stream][:tags] = tags
+        else                               nil
+        end
       end
 
       def named_tags
         stream[:stream].merge!(log.named_tags) if log.named_tags.respond_to?(:empty?) && !log.named_tags.empty?
+        stream[:stream].merge!(log.instance_named_tags) if log.instance_named_tags.respond_to?(:empty?) && !log.instance_named_tags.empty?
       end
 
       def context

--- a/lib/semantic_logger/formatters/raw.rb
+++ b/lib/semantic_logger/formatters/raw.rb
@@ -58,12 +58,23 @@ module SemanticLogger
 
       # Tags
       def tags
-        hash[:tags] = log.tags if log.tags && !log.tags.empty?
+        instance_tags = log.instance_tags
+        tags          = log.tags
+        has_instance  = instance_tags && !instance_tags.empty?
+        has_tags      = tags && !tags.empty?
+
+        case
+        when has_instance && has_tags then hash[:tags] = tags + instance_tags
+        when has_instance             then hash[:tags] = instance_tags
+        when has_tags                 then hash[:tags] = tags
+        else                               nil
+        end
       end
 
       # Named Tags
       def named_tags
         hash[:named_tags] = log.named_tags if log.named_tags && !log.named_tags.empty?
+        hash[:named_tags] = hash.fetch(:named_tags, {}).merge(log.instance_named_tags) if log.instance_named_tags && !log.instance_named_tags.empty?
       end
 
       # Duration

--- a/lib/semantic_logger/formatters/signalfx.rb
+++ b/lib/semantic_logger/formatters/signalfx.rb
@@ -62,7 +62,9 @@ module SemanticLogger
             h[name] = value unless value.empty?
           end
         else
-          log.named_tags.each_pair do |name, value|
+          named_tags = log.named_tags
+          named_tags = named_tags.merge(log.instance_named_tags) if log.instance_named_tags && !log.instance_named_tags.empty?
+          named_tags.each_pair do |name, value|
             name  = name.to_sym
             value = value.to_s
             next if value.empty?

--- a/lib/semantic_logger/log.rb
+++ b/lib/semantic_logger/log.rb
@@ -28,6 +28,12 @@ module SemanticLogger
   # tags
   #   Any tags active on the thread when the log call was made
   #
+  # instance_tags
+  #   Any positional tags active on the logger instance when the log call was made
+  #
+  # instance_named_tags
+  #   Any named tags active on the logger instance when the log call was made
+  #
   # level_index
   #   Internal index of the log level
   #
@@ -55,16 +61,18 @@ module SemanticLogger
 
     attr_accessor :level, :level_index, :name, :message, :time, :duration,
                   :payload, :exception, :thread_name, :backtrace,
-                  :tags, :named_tags, :context,
+                  :tags, :named_tags, :instance_tags, :instance_named_tags, :context,
                   :metric, :metric_amount, :dimensions
 
-    def initialize(name, level, index = nil)
+    def initialize(name, level, index = nil, instance_tags = [], instance_named_tags = {})
       @level       = level
       @thread_name = Thread.current.name
       @name        = name
       @time        = Time.now
       @tags        = SemanticLogger.tags
       @named_tags  = SemanticLogger.named_tags
+      @instance_tags = instance_tags
+      @instance_named_tags = instance_named_tags
       @level_index = index.nil? ? Levels.index(level) : index
     end
 

--- a/lib/semantic_logger/loggable.rb
+++ b/lib/semantic_logger/loggable.rb
@@ -42,7 +42,18 @@ module SemanticLogger
 
         # Returns [SemanticLogger::Logger] class level logger
         def self.logger
-          @semantic_logger ||= SemanticLogger[self]
+          return @semantic_logger if @semantic_logger
+
+          tags = @logger_instance_tags
+          named_tags = @logger_instance_named_tags
+          base = SemanticLogger[self]
+
+          case
+          when tags && named_tags then @semantic_logger = base.tagged(*tags, **named_tags)
+          when tags then @semantic_logger = base.tagged(*tags)
+          when named_tags then @semantic_logger = base.tagged(**named_tags)
+          else @semantic_logger = base
+          end
         end
 
         # Replace instance class level logger
@@ -112,6 +123,11 @@ module SemanticLogger
         MEASURE_METHOD
         # {"#{visibility} :#{method_name}" unless visibility == :public}
         true
+      end
+
+      def logger_tagged(*tags, **named_tags)
+        @logger_instance_tags = tags
+        @logger_instance_named_tags = named_tags
       end
 
       private

--- a/lib/semantic_logger/logger.rb
+++ b/lib/semantic_logger/logger.rb
@@ -56,7 +56,15 @@ module SemanticLogger
     #    regular expression. All other messages will be ignored
     #    Proc: Only include log messages where the supplied Proc returns true
     #          The Proc must return true or false
-    def initialize(klass, level = nil, filter = nil)
+    #
+    #  instance_tags
+    #    Tags to be added to all log messages for this logger instance
+    #    Default: []
+    #
+    #  instance_named_tags
+    #    Named tags to be added to all log messages for this logger instance
+    #    Default: {}
+    def initialize(klass, level = nil, filter = nil, instance_tags = [], instance_named_tags = {})
       super
     end
 

--- a/lib/semantic_logger/subscriber.rb
+++ b/lib/semantic_logger/subscriber.rb
@@ -108,8 +108,12 @@ module SemanticLogger
     #   metrics: [Boolean]
     #     Whether to log metric only entries with this subscriber.
     #     Default: false
+    #
+    #   instance_named_tags: [Hash]
+    #     Named tags to be added to all log messages for this subscriber
+    #     Default: {}
     def initialize(level: nil, formatter: nil, filter: nil, application: nil, environment: nil, host: nil,
-                   metrics: false, &block)
+                   metrics: false, instance_tags: [], instance_named_tags: {}, &block)
       self.formatter = block || formatter
       @application   = application
       @environment   = environment
@@ -118,7 +122,7 @@ module SemanticLogger
 
       # Subscribers don't take a class name, so use this class name if a subscriber
       # is logged to directly.
-      super(self.class, level, filter)
+      super(self.class, level, filter, instance_tags, instance_named_tags)
     end
 
     # Return the level index for fast comparisons.

--- a/lib/semantic_logger/test/capture_log_events.rb
+++ b/lib/semantic_logger/test/capture_log_events.rb
@@ -20,6 +20,12 @@ module SemanticLogger
     #     end
     #   end
     class CaptureLogEvents < SemanticLogger::Subscriber
+      def self.copy(instance)
+        new_instance = super
+        new_instance.events = []
+        new_instance
+      end
+
       attr_accessor :events
 
       # By default collect all log levels, and collect metric only log events.

--- a/lib/semantic_logger/test/minitest.rb
+++ b/lib/semantic_logger/test/minitest.rb
@@ -24,7 +24,8 @@ module SemanticLogger
       def assert_semantic_logger_event(event, level: nil, name: nil, message: nil, message_includes: nil,
                                        payload: nil, payload_includes: nil,
                                        exception: nil, exception_includes: nil, backtrace: nil,
-                                       thread_name: nil, tags: nil, named_tags: nil, context: nil,
+                                       thread_name: nil, tags: nil, instance_tags: nil,
+                                       named_tags: nil, instance_named_tags: nil, context: nil,
                                        level_index: nil, duration: nil, time: nil,
                                        metric: nil, metric_amount: nil, dimensions: nil)
         assert event, "No log event occurred"
@@ -34,7 +35,9 @@ module SemanticLogger
         assert_semantic_logger_entry(event, :level, level)
         assert_semantic_logger_entry(event, :thread_name, thread_name)
         assert_semantic_logger_entry(event, :tags, tags)
+        assert_semantic_logger_entry(event, :instance_tags, instance_tags)
         assert_semantic_logger_entry(event, :named_tags, named_tags)
+        assert_semantic_logger_entry(event, :instance_named_tags, instance_named_tags)
         assert_semantic_logger_entry(event, :context, context)
         assert_semantic_logger_entry(event, :metric, metric)
         assert_semantic_logger_entry(event, :metric_amount, metric_amount)

--- a/test/loggable_test.rb
+++ b/test/loggable_test.rb
@@ -27,6 +27,15 @@ class AppenderFileTest < Minitest::Test
     include SemanticLogger::Loggable
   end
 
+  class TestTaggedClassLogger
+    include SemanticLogger::Loggable
+
+    POSITIONAL_TAG_DATA = ["tag1", "tag2"].freeze
+    TAG_DATA = {tag1: "value1", tag2: "value2"}.freeze
+
+    logger_tagged(*POSITIONAL_TAG_DATA, **TAG_DATA)
+  end
+
   describe SemanticLogger::Loggable do
     describe "inheritance" do
       it "should give child classes their own logger" do
@@ -77,6 +86,16 @@ class AppenderFileTest < Minitest::Test
 
       it "has instance level logger" do
         TestAttribute.new.logger.is_a?(SemanticLogger::Logger)
+      end
+    end
+
+    describe "sample tagged class logger" do
+      it "has instance named tags set" do
+        assert_equal TestTaggedClassLogger::TAG_DATA, TestTaggedClassLogger.logger.instance_named_tags
+      end
+
+      it "has instance tags set" do
+        assert_equal TestTaggedClassLogger::POSITIONAL_TAG_DATA, TestTaggedClassLogger.logger.instance_tags
       end
     end
   end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -153,5 +153,163 @@ class LoggerTest < Minitest::Test
         end
       end
     end
+
+    describe ".tagged without block" do
+      it "creates a child logger with instance named tags merged with parent" do
+        parent_tag_data = {parent_tag: "parent_value"}
+        child_tag_data = {tag1: "value1", tag2: "value2"}
+        parent_logger = logger.tagged(**parent_tag_data)
+        child_logger = parent_logger.tagged(**child_tag_data)
+
+        child_logger.info("hello world")
+
+        assert_equal parent_tag_data, parent_logger.instance_named_tags
+        assert_equal parent_tag_data.merge(child_tag_data), child_logger.instance_named_tags
+      end
+
+      it "outputs log entries with different instance named tags from the parent" do
+        parent_tag_data = {parent_tag: "parent_value"}
+        child_tag_data = {tag1: "value1", tag2: "value2"}
+        parent_logger = logger.tagged(**parent_tag_data)
+        child_logger = parent_logger.tagged(**child_tag_data)
+
+        parent_logger.info("hello parent")
+
+        assert log_parent = parent_logger.events.first
+        assert_equal "hello parent", log_parent.message
+        assert_equal parent_tag_data, log_parent.instance_named_tags
+
+        child_logger.info("hello child")
+
+        assert log_child = child_logger.events.first
+        assert_equal "hello child", log_child.message
+        assert_equal parent_tag_data.merge(child_tag_data), log_child.instance_named_tags
+      end
+
+      it "creates a child logger with instance positional tags" do
+        tagged_logger = logger.tagged("tag1", "tag2")
+
+        tagged_logger.info("hello world")
+
+        assert_equal %w[tag1 tag2], tagged_logger.instance_tags
+        assert log = tagged_logger.events.first
+        assert_equal "hello world", log.message
+        assert_equal %w[tag1 tag2], log.instance_tags
+      end
+
+      it "creates a child logger with instance positional tags merged with parent" do
+        parent_logger = logger.tagged("parent_tag")
+        child_logger = parent_logger.tagged("child_tag1", "child_tag2")
+
+        child_logger.info("hello world")
+
+        assert_equal %w[parent_tag], parent_logger.instance_tags
+        assert_equal %w[parent_tag child_tag1 child_tag2], child_logger.instance_tags
+      end
+
+      it "creates a child logger with both positional and named instance tags" do
+        tagged_logger = logger.tagged("tag1", "tag2", user: "alice", request_id: "123")
+
+        tagged_logger.info("hello world")
+
+        assert_equal %w[tag1 tag2], tagged_logger.instance_tags
+        assert_equal({user: "alice", request_id: "123"}, tagged_logger.instance_named_tags)
+        assert log = tagged_logger.events.first
+        assert_equal %w[tag1 tag2], log.instance_tags
+        assert_equal({user: "alice", request_id: "123"}, log.instance_named_tags)
+      end
+
+      it "prefixes instance tags to thread tags in log entries" do
+        tagged_logger = logger.tagged("instance_tag")
+
+        SemanticLogger.tagged("thread_tag") do
+          tagged_logger.info("hello world")
+        end
+
+        assert log = tagged_logger.events.first
+        assert_equal %w[instance_tag], log.instance_tags
+        assert_equal %w[thread_tag], log.tags
+      end
+
+      it "pushes instance tags to thread when tagged is called with a block" do
+        tagged_logger = logger.tagged("instance_tag1", "instance_tag2")
+
+        tagged_logger.tagged("block_tag") do
+          tagged_logger.info("hello world")
+        end
+
+        assert log = tagged_logger.events.first
+        assert_equal "hello world", log.message
+        assert_equal %w[instance_tag1 instance_tag2 block_tag], log.tags
+      end
+
+      it "pushes instance named tags to thread when tagged is called with a block" do
+        tagged_logger = logger.tagged(user: "alice", request_id: "123")
+
+        tagged_logger.tagged do
+          tagged_logger.info("hello world")
+        end
+
+        assert log = tagged_logger.events.first
+        assert_equal "hello world", log.message
+        assert_equal({user: "alice", request_id: "123"}, log.named_tags)
+      end
+
+      it "merges instance named tags with block named tags" do
+        tagged_logger = logger.tagged(user: "alice")
+
+        tagged_logger.tagged(request_id: "123") do
+          tagged_logger.info("hello world")
+        end
+
+        assert log = tagged_logger.events.first
+        assert_equal "hello world", log.message
+        assert_equal({user: "alice", request_id: "123"}, log.named_tags)
+      end
+
+      it "combines instance tags and named tags with block tags" do
+        tagged_logger = logger.tagged("instance_tag", user: "alice")
+
+        tagged_logger.tagged("block_tag", request_id: "123") do
+          tagged_logger.info("hello world")
+        end
+
+        assert log = tagged_logger.events.first
+        assert_equal "hello world", log.message
+        assert_equal %w[instance_tag block_tag], log.tags
+        assert_equal({user: "alice", request_id: "123"}, log.named_tags)
+      end
+
+      it "makes instance tags visible to other loggers via thread variables" do
+        child_logger = logger.tagged("child1", n_child1: "val1")
+
+        child_logger.tagged("tagged1", n_tagged1: "tval1") do
+          thread_logger = SemanticLogger::Test::CaptureLogEvents.new
+          thread_logger.info("whatever")
+
+          log = thread_logger.events.first
+
+          assert_equal %w[child1 tagged1], log.tags
+          assert_equal({n_child1: "val1", n_tagged1: "tval1"}, log.named_tags)
+        end
+      end
+
+      it "combines thread tags with nested child logger instance tags" do
+        child_logger = logger.tagged("child1", n_child1: "val1")
+
+        child_logger.tagged("tagged1", n_tagged1: "tval1") do
+          thread_logger = SemanticLogger::Test::CaptureLogEvents.new
+          cthread_log = thread_logger.tagged("t1", tn1: "tnval1")
+          cthread_log.info("whatever")
+
+          log = cthread_log.events.first
+
+          assert_equal %w[child1 tagged1], log.tags
+          assert_equal({n_child1: "val1", n_tagged1: "tval1"}, log.named_tags)
+          assert_equal %w[t1], log.instance_tags
+          assert_equal({tn1: "tnval1"}, log.instance_named_tags)
+        end
+      end
+    end
   end
 end

--- a/test/tag_merging/color_test.rb
+++ b/test/tag_merging/color_test.rb
@@ -1,0 +1,115 @@
+require_relative "../test_helper"
+
+module SemanticLogger
+  module Formatters
+    class ColorTagMergingTest < Minitest::Test
+      describe "Color formatter tag merging" do
+        let(:log_time) { Time.utc(2017, 1, 14, 8, 32, 5.375276) }
+        let(:formatter) { SemanticLogger::Formatters::Color.new }
+
+        def build_log(instance_tags: [], instance_named_tags: {}, tags: [], named_tags: {})
+          log = SemanticLogger::Log.new("TagMergingTest", :info, nil, instance_tags, instance_named_tags)
+          log.time = log_time
+          log.tags = tags unless tags.empty?
+          log.named_tags = named_tags unless named_tags.empty?
+          log
+        end
+
+        describe "positional tags" do
+          it "returns nil when no tags present" do
+            log = build_log
+
+            formatter.call(log, nil)
+
+            assert_nil formatter.tags
+          end
+
+          it "formats thread tags only" do
+            log = build_log(tags: %w[thread1 thread2])
+
+            formatter.call(log, nil)
+
+            assert_includes formatter.tags, "thread1"
+            assert_includes formatter.tags, "thread2"
+          end
+
+          it "formats instance tags only" do
+            log = build_log(instance_tags: %w[instance1 instance2])
+
+            formatter.call(log, nil)
+
+            assert_includes formatter.tags, "instance1"
+            assert_includes formatter.tags, "instance2"
+          end
+
+          it "concatenates thread tags before instance tags" do
+            log = build_log(
+              tags: %w[thread1],
+              instance_tags: %w[instance1]
+            )
+
+            formatter.call(log, nil)
+            output = formatter.tags
+
+            thread_pos = output.index("thread1")
+            instance_pos = output.index("instance1")
+
+            assert thread_pos < instance_pos
+          end
+        end
+
+        describe "named tags" do
+          it "returns nil when no named tags present" do
+            log = build_log
+
+            formatter.call(log, nil)
+
+            assert_nil formatter.named_tags
+          end
+
+          it "formats thread named tags only" do
+            log = build_log(named_tags: {request_id: "123", user: "alice"})
+
+            formatter.call(log, nil)
+
+            assert_includes formatter.named_tags, "request_id: 123"
+            assert_includes formatter.named_tags, "user: alice"
+          end
+
+          it "formats instance named tags only" do
+            log = build_log(instance_named_tags: {service: "api", version: "2.0"})
+
+            formatter.call(log, nil)
+
+            assert_includes formatter.named_tags, "service: api"
+            assert_includes formatter.named_tags, "version: 2.0"
+          end
+
+          it "merges thread and instance named tags" do
+            log = build_log(
+              named_tags: {request_id: "123"},
+              instance_named_tags: {service: "api"}
+            )
+
+            formatter.call(log, nil)
+
+            assert_includes formatter.named_tags, "request_id: 123"
+            assert_includes formatter.named_tags, "service: api"
+          end
+
+          it "instance named tags override thread named tags on conflict" do
+            log = build_log(
+              named_tags: {user: "thread-user", request_id: "123"},
+              instance_named_tags: {user: "instance-user", service: "api"}
+            )
+
+            formatter.call(log, nil)
+
+            assert_includes formatter.named_tags, "user: instance-user"
+            refute_includes formatter.named_tags, "thread-user"
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/tag_merging/default_test.rb
+++ b/test/tag_merging/default_test.rb
@@ -1,0 +1,116 @@
+require_relative "../test_helper"
+
+module SemanticLogger
+  module Formatters
+    class DefaultTagMergingTest < Minitest::Test
+      describe "Default formatter tag merging" do
+        let(:log_time) { Time.utc(2017, 1, 14, 8, 32, 5.375276) }
+        let(:formatter) { SemanticLogger::Formatters::Default.new }
+
+        def build_log(instance_tags: [], instance_named_tags: {}, tags: [], named_tags: {})
+          log = SemanticLogger::Log.new("TagMergingTest", :info, nil, instance_tags, instance_named_tags)
+          log.time = log_time
+          log.tags = tags unless tags.empty?
+          log.named_tags = named_tags unless named_tags.empty?
+          log
+        end
+
+        describe "positional tags" do
+          it "returns nil when no tags present" do
+            log = build_log
+
+            formatter.call(log, nil)
+
+            assert_nil formatter.tags
+          end
+
+          it "formats thread tags only" do
+            log = build_log(tags: %w[thread1 thread2])
+
+            formatter.call(log, nil)
+
+            assert_equal "[thread1] [thread2]", formatter.tags
+          end
+
+          it "formats instance tags only" do
+            log = build_log(instance_tags: %w[instance1 instance2])
+
+            formatter.call(log, nil)
+
+            assert_equal "[instance1] [instance2]", formatter.tags
+          end
+
+          it "concatenates thread tags before instance tags" do
+            log = build_log(
+              tags: %w[thread1 thread2],
+              instance_tags: %w[instance1 instance2]
+            )
+
+            formatter.call(log, nil)
+
+            assert_equal "[thread1] [thread2] [instance1] [instance2]", formatter.tags
+          end
+
+          it "preserves duplicates when same tag in both sources" do
+            log = build_log(
+              tags: %w[shared unique-thread],
+              instance_tags: %w[shared unique-instance]
+            )
+
+            formatter.call(log, nil)
+
+            assert_equal "[shared] [unique-thread] [shared] [unique-instance]", formatter.tags
+          end
+        end
+
+        describe "named tags" do
+          it "returns nil when no named tags present" do
+            log = build_log
+
+            formatter.call(log, nil)
+
+            assert_nil formatter.named_tags
+          end
+
+          it "formats thread named tags only" do
+            log = build_log(named_tags: {request_id: "123", user: "alice"})
+
+            formatter.call(log, nil)
+
+            assert_equal "{request_id: 123, user: alice}", formatter.named_tags
+          end
+
+          it "formats instance named tags only" do
+            log = build_log(instance_named_tags: {service: "api", version: "2.0"})
+
+            formatter.call(log, nil)
+
+            assert_equal "{service: api, version: 2.0}", formatter.named_tags
+          end
+
+          it "merges thread and instance named tags" do
+            log = build_log(
+              named_tags: {request_id: "123"},
+              instance_named_tags: {service: "api"}
+            )
+
+            formatter.call(log, nil)
+
+            assert_equal "{request_id: 123, service: api}", formatter.named_tags
+          end
+
+          it "instance named tags override thread named tags on conflict" do
+            log = build_log(
+              named_tags: {user: "thread-user", request_id: "123"},
+              instance_named_tags: {user: "instance-user", service: "api"}
+            )
+
+            formatter.call(log, nil)
+
+            assert_equal "{user: instance-user, request_id: 123, service: api}", formatter.named_tags
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/tag_merging/fluentd_test.rb
+++ b/test/tag_merging/fluentd_test.rb
@@ -1,0 +1,121 @@
+require_relative "../test_helper"
+require "json"
+
+module SemanticLogger
+  module Formatters
+    class FluentdTagMergingTest < Minitest::Test
+      describe "Fluentd formatter tag merging" do
+        let(:log_time) { Time.utc(2017, 1, 14, 8, 32, 5.375276) }
+        let(:formatter) { SemanticLogger::Formatters::Fluentd.new(log_host: false, log_application: false, log_environment: false) }
+
+        def build_log(instance_tags: [], instance_named_tags: {}, tags: [], named_tags: {})
+          log = SemanticLogger::Log.new("TagMergingTest", :info, nil, instance_tags, instance_named_tags)
+          log.time = log_time
+          log.tags = tags unless tags.empty?
+          log.named_tags = named_tags unless named_tags.empty?
+          log
+        end
+
+        def parsed_result(log)
+          JSON.parse(formatter.call(log, nil), symbolize_names: true)
+        end
+
+        describe "positional tags" do
+          it "omits tags key when no tags present" do
+            log = build_log
+
+            result = parsed_result(log)
+
+            refute result.key?(:tags)
+          end
+
+          it "returns thread tags only" do
+            log = build_log(tags: %w[thread1 thread2])
+
+            result = parsed_result(log)
+
+            assert_equal %w[thread1 thread2], result[:tags]
+          end
+
+          it "returns instance tags only" do
+            log = build_log(instance_tags: %w[instance1 instance2])
+
+            result = parsed_result(log)
+
+            assert_equal %w[instance1 instance2], result[:tags]
+          end
+
+          it "concatenates thread tags before instance tags" do
+            log = build_log(
+              tags: %w[thread1 thread2],
+              instance_tags: %w[instance1 instance2]
+            )
+
+            result = parsed_result(log)
+
+            assert_equal %w[thread1 thread2 instance1 instance2], result[:tags]
+          end
+
+          it "preserves duplicates when same tag in both sources" do
+            log = build_log(
+              tags: %w[shared unique-thread],
+              instance_tags: %w[shared unique-instance]
+            )
+
+            result = parsed_result(log)
+
+            assert_equal %w[shared unique-thread shared unique-instance], result[:tags]
+          end
+        end
+
+        describe "named tags" do
+          it "omits named_tags key when no named tags present" do
+            log = build_log
+
+            result = parsed_result(log)
+
+            refute result.key?(:named_tags)
+          end
+
+          it "returns thread named tags only" do
+            log = build_log(named_tags: {request_id: "123", user: "alice"})
+
+            result = parsed_result(log)
+
+            assert_equal({request_id: "123", user: "alice"}, result[:named_tags])
+          end
+
+          it "returns instance named tags only" do
+            log = build_log(instance_named_tags: {service: "api", version: "2.0"})
+
+            result = parsed_result(log)
+
+            assert_equal({service: "api", version: "2.0"}, result[:named_tags])
+          end
+
+          it "merges thread and instance named tags" do
+            log = build_log(
+              named_tags: {request_id: "123"},
+              instance_named_tags: {service: "api"}
+            )
+
+            result = parsed_result(log)
+
+            assert_equal({request_id: "123", service: "api"}, result[:named_tags])
+          end
+
+          it "instance named tags override thread named tags on conflict" do
+            log = build_log(
+              named_tags: {user: "thread-user", request_id: "123"},
+              instance_named_tags: {user: "instance-user", service: "api"}
+            )
+
+            result = parsed_result(log)
+
+            assert_equal({user: "instance-user", request_id: "123", service: "api"}, result[:named_tags])
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/tag_merging/json_test.rb
+++ b/test/tag_merging/json_test.rb
@@ -1,0 +1,121 @@
+require_relative "../test_helper"
+require "json"
+
+module SemanticLogger
+  module Formatters
+    class JsonTagMergingTest < Minitest::Test
+      describe "Json formatter tag merging" do
+        let(:log_time) { Time.utc(2017, 1, 14, 8, 32, 5.375276) }
+        let(:formatter) { SemanticLogger::Formatters::Json.new(log_host: false, log_application: false, log_environment: false) }
+
+        def build_log(instance_tags: [], instance_named_tags: {}, tags: [], named_tags: {})
+          log = SemanticLogger::Log.new("TagMergingTest", :info, nil, instance_tags, instance_named_tags)
+          log.time = log_time
+          log.tags = tags unless tags.empty?
+          log.named_tags = named_tags unless named_tags.empty?
+          log
+        end
+
+        def parsed_result(log)
+          JSON.parse(formatter.call(log, nil), symbolize_names: true)
+        end
+
+        describe "positional tags" do
+          it "omits tags key when no tags present" do
+            log = build_log
+
+            result = parsed_result(log)
+
+            refute result.key?(:tags)
+          end
+
+          it "returns thread tags only" do
+            log = build_log(tags: %w[thread1 thread2])
+
+            result = parsed_result(log)
+
+            assert_equal %w[thread1 thread2], result[:tags]
+          end
+
+          it "returns instance tags only" do
+            log = build_log(instance_tags: %w[instance1 instance2])
+
+            result = parsed_result(log)
+
+            assert_equal %w[instance1 instance2], result[:tags]
+          end
+
+          it "concatenates thread tags before instance tags" do
+            log = build_log(
+              tags: %w[thread1 thread2],
+              instance_tags: %w[instance1 instance2]
+            )
+
+            result = parsed_result(log)
+
+            assert_equal %w[thread1 thread2 instance1 instance2], result[:tags]
+          end
+
+          it "preserves duplicates when same tag in both sources" do
+            log = build_log(
+              tags: %w[shared unique-thread],
+              instance_tags: %w[shared unique-instance]
+            )
+
+            result = parsed_result(log)
+
+            assert_equal %w[shared unique-thread shared unique-instance], result[:tags]
+          end
+        end
+
+        describe "named tags" do
+          it "omits named_tags key when no named tags present" do
+            log = build_log
+
+            result = parsed_result(log)
+
+            refute result.key?(:named_tags)
+          end
+
+          it "returns thread named tags only" do
+            log = build_log(named_tags: {request_id: "123", user: "alice"})
+
+            result = parsed_result(log)
+
+            assert_equal({request_id: "123", user: "alice"}, result[:named_tags])
+          end
+
+          it "returns instance named tags only" do
+            log = build_log(instance_named_tags: {service: "api", version: "2.0"})
+
+            result = parsed_result(log)
+
+            assert_equal({service: "api", version: "2.0"}, result[:named_tags])
+          end
+
+          it "merges thread and instance named tags" do
+            log = build_log(
+              named_tags: {request_id: "123"},
+              instance_named_tags: {service: "api"}
+            )
+
+            result = parsed_result(log)
+
+            assert_equal({request_id: "123", service: "api"}, result[:named_tags])
+          end
+
+          it "instance named tags override thread named tags on conflict" do
+            log = build_log(
+              named_tags: {user: "thread-user", request_id: "123"},
+              instance_named_tags: {user: "instance-user", service: "api"}
+            )
+
+            result = parsed_result(log)
+
+            assert_equal({user: "instance-user", request_id: "123", service: "api"}, result[:named_tags])
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/tag_merging/logfmt_test.rb
+++ b/test/tag_merging/logfmt_test.rb
@@ -1,0 +1,96 @@
+require_relative "../test_helper"
+
+module SemanticLogger
+  module Formatters
+    class LogfmtTagMergingTest < Minitest::Test
+      describe "Logfmt formatter tag merging" do
+        let(:log_time) { Time.utc(2017, 1, 14, 8, 32, 5.375276) }
+        let(:formatter) { SemanticLogger::Formatters::Logfmt.new(log_host: false, log_application: false, log_environment: false) }
+
+        def build_log(instance_tags: [], instance_named_tags: {}, tags: [], named_tags: {})
+          log = SemanticLogger::Log.new("TagMergingTest", :info, nil, instance_tags, instance_named_tags)
+          log.time = log_time
+          log.tags = tags unless tags.empty?
+          log.named_tags = named_tags unless named_tags.empty?
+          log
+        end
+
+        describe "positional tags" do
+          it "includes thread tags as boolean keys" do
+            log = build_log(tags: %w[thread1 thread2])
+
+            result = formatter.call(log, nil)
+
+            assert_includes result, "thread1=true"
+            assert_includes result, "thread2=true"
+          end
+
+          it "includes instance tags as boolean keys" do
+            log = build_log(instance_tags: %w[instance1 instance2])
+
+            result = formatter.call(log, nil)
+
+            assert_includes result, "instance1=true"
+            assert_includes result, "instance2=true"
+          end
+
+          it "includes both thread and instance tags" do
+            log = build_log(
+              tags: %w[thread1],
+              instance_tags: %w[instance1]
+            )
+
+            result = formatter.call(log, nil)
+
+            assert_includes result, "thread1=true"
+            assert_includes result, "instance1=true"
+          end
+        end
+
+        describe "named tags" do
+          it "includes thread named tags" do
+            log = build_log(named_tags: {request_id: "123", user: "alice"})
+
+            result = formatter.call(log, nil)
+
+            assert_includes result, "request_id=\"123\""
+            assert_includes result, "user=\"alice\""
+          end
+
+          it "includes instance named tags" do
+            log = build_log(instance_named_tags: {service: "api", version: "2.0"})
+
+            result = formatter.call(log, nil)
+
+            assert_includes result, "service=\"api\""
+            assert_includes result, "version=\"2.0\""
+          end
+
+          it "merges thread and instance named tags" do
+            log = build_log(
+              named_tags: {request_id: "123"},
+              instance_named_tags: {service: "api"}
+            )
+
+            result = formatter.call(log, nil)
+
+            assert_includes result, "request_id=\"123\""
+            assert_includes result, "service=\"api\""
+          end
+
+          it "instance named tags override thread named tags on conflict" do
+            log = build_log(
+              named_tags: {user: "thread-user", request_id: "123"},
+              instance_named_tags: {user: "instance-user", service: "api"}
+            )
+
+            result = formatter.call(log, nil)
+
+            assert_includes result, "user=\"instance-user\""
+            refute_includes result, "thread-user"
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/tag_merging/loki_test.rb
+++ b/test/tag_merging/loki_test.rb
@@ -1,0 +1,132 @@
+require_relative "../test_helper"
+require "json"
+
+module SemanticLogger
+  module Formatters
+    class LokiTagMergingTest < Minitest::Test
+      MOCK_LOGGER = Struct.new(:host, :application, :name, :environment)
+
+      describe "Loki formatter tag merging" do
+        let(:log_time) { Time.utc(2017, 1, 14, 8, 32, 5.375276) }
+        let(:formatter) { SemanticLogger::Formatters::Loki.new }
+        let(:logger) { MOCK_LOGGER.new("test_host", "test_app", "TestLogger", "test") }
+
+        def build_log(instance_tags: [], instance_named_tags: {}, tags: [], named_tags: {})
+          log = SemanticLogger::Log.new("TagMergingTest", :info, nil, instance_tags, instance_named_tags)
+          log.time = log_time
+          log.thread_name = "test-thread"
+          log.message = "test message"
+          log.tags = tags unless tags.empty?
+          log.named_tags = named_tags unless named_tags.empty?
+          log
+        end
+
+        def stream_data(log)
+          JSON.parse(formatter.call(log, logger))["streams"].first["stream"]
+        end
+
+        describe "positional tags" do
+          it "omits tags key when no tags present" do
+            log = build_log
+
+            result = stream_data(log)
+
+            refute result.key?("tags")
+          end
+
+          it "returns thread tags only" do
+            log = build_log(tags: %w[thread1 thread2])
+
+            result = stream_data(log)
+
+            assert_equal %w[thread1 thread2], result["tags"]
+          end
+
+          it "returns instance tags only" do
+            log = build_log(instance_tags: %w[instance1 instance2])
+
+            result = stream_data(log)
+
+            assert_equal %w[instance1 instance2], result["tags"]
+          end
+
+          it "concatenates thread tags before instance tags" do
+            log = build_log(
+              tags: %w[thread1 thread2],
+              instance_tags: %w[instance1 instance2]
+            )
+
+            result = stream_data(log)
+
+            assert_equal %w[thread1 thread2 instance1 instance2], result["tags"]
+          end
+
+          it "preserves duplicates when same tag in both sources" do
+            log = build_log(
+              tags: %w[shared unique-thread],
+              instance_tags: %w[shared unique-instance]
+            )
+
+            result = stream_data(log)
+
+            assert_equal %w[shared unique-thread shared unique-instance], result["tags"]
+          end
+        end
+
+        describe "named tags" do
+          it "omits named tag keys when no named tags present" do
+            log = build_log
+
+            result = stream_data(log)
+
+            refute result.key?("request_id")
+            refute result.key?("user")
+          end
+
+          it "returns thread named tags only" do
+            log = build_log(named_tags: {request_id: "123", user: "alice"})
+
+            result = stream_data(log)
+
+            assert_equal "123", result["request_id"]
+            assert_equal "alice", result["user"]
+          end
+
+          it "returns instance named tags only" do
+            log = build_log(instance_named_tags: {service: "api", version: "2.0"})
+
+            result = stream_data(log)
+
+            assert_equal "api", result["service"]
+            assert_equal "2.0", result["version"]
+          end
+
+          it "merges thread and instance named tags" do
+            log = build_log(
+              named_tags: {request_id: "123"},
+              instance_named_tags: {service: "api"}
+            )
+
+            result = stream_data(log)
+
+            assert_equal "123", result["request_id"]
+            assert_equal "api", result["service"]
+          end
+
+          it "instance named tags override thread named tags on conflict" do
+            log = build_log(
+              named_tags: {user: "thread-user", request_id: "123"},
+              instance_named_tags: {user: "instance-user", service: "api"}
+            )
+
+            result = stream_data(log)
+
+            assert_equal "instance-user", result["user"]
+            assert_equal "123", result["request_id"]
+            assert_equal "api", result["service"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/tag_merging/one_line_test.rb
+++ b/test/tag_merging/one_line_test.rb
@@ -1,0 +1,116 @@
+require_relative "../test_helper"
+
+module SemanticLogger
+  module Formatters
+    class OneLineTagMergingTest < Minitest::Test
+      describe "OneLine formatter tag merging" do
+        let(:log_time) { Time.utc(2017, 1, 14, 8, 32, 5.375276) }
+        let(:formatter) { SemanticLogger::Formatters::OneLine.new }
+
+        def build_log(instance_tags: [], instance_named_tags: {}, tags: [], named_tags: {})
+          log = SemanticLogger::Log.new("TagMergingTest", :info, nil, instance_tags, instance_named_tags)
+          log.time = log_time
+          log.tags = tags unless tags.empty?
+          log.named_tags = named_tags unless named_tags.empty?
+          log
+        end
+
+        describe "positional tags" do
+          it "returns nil when no tags present" do
+            log = build_log
+
+            formatter.call(log, nil)
+
+            assert_nil formatter.tags
+          end
+
+          it "formats thread tags only" do
+            log = build_log(tags: %w[thread1 thread2])
+
+            formatter.call(log, nil)
+
+            assert_equal "[thread1] [thread2]", formatter.tags
+          end
+
+          it "formats instance tags only" do
+            log = build_log(instance_tags: %w[instance1 instance2])
+
+            formatter.call(log, nil)
+
+            assert_equal "[instance1] [instance2]", formatter.tags
+          end
+
+          it "concatenates thread tags before instance tags" do
+            log = build_log(
+              tags: %w[thread1 thread2],
+              instance_tags: %w[instance1 instance2]
+            )
+
+            formatter.call(log, nil)
+
+            assert_equal "[thread1] [thread2] [instance1] [instance2]", formatter.tags
+          end
+
+          it "preserves duplicates when same tag in both sources" do
+            log = build_log(
+              tags: %w[shared unique-thread],
+              instance_tags: %w[shared unique-instance]
+            )
+
+            formatter.call(log, nil)
+
+            assert_equal "[shared] [unique-thread] [shared] [unique-instance]", formatter.tags
+          end
+        end
+
+        describe "named tags" do
+          it "returns nil when no named tags present" do
+            log = build_log
+
+            formatter.call(log, nil)
+
+            assert_nil formatter.named_tags
+          end
+
+          it "formats thread named tags only" do
+            log = build_log(named_tags: {request_id: "123", user: "alice"})
+
+            formatter.call(log, nil)
+
+            assert_equal "{request_id: 123, user: alice}", formatter.named_tags
+          end
+
+          it "formats instance named tags only" do
+            log = build_log(instance_named_tags: {service: "api", version: "2.0"})
+
+            formatter.call(log, nil)
+
+            assert_equal "{service: api, version: 2.0}", formatter.named_tags
+          end
+
+          it "merges thread and instance named tags" do
+            log = build_log(
+              named_tags: {request_id: "123"},
+              instance_named_tags: {service: "api"}
+            )
+
+            formatter.call(log, nil)
+
+            assert_equal "{request_id: 123, service: api}", formatter.named_tags
+          end
+
+          it "instance named tags override thread named tags on conflict" do
+            log = build_log(
+              named_tags: {user: "thread-user", request_id: "123"},
+              instance_named_tags: {user: "instance-user", service: "api"}
+            )
+
+            formatter.call(log, nil)
+
+            assert_equal "{user: instance-user, request_id: 123, service: api}", formatter.named_tags
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/tag_merging/raw_test.rb
+++ b/test/tag_merging/raw_test.rb
@@ -1,0 +1,116 @@
+require_relative "../test_helper"
+
+module SemanticLogger
+  module Formatters
+    class RawTagMergingTest < Minitest::Test
+      describe "Raw formatter tag merging" do
+        let(:log_time) { Time.utc(2017, 1, 14, 8, 32, 5.375276) }
+        let(:formatter) { SemanticLogger::Formatters::Raw.new(log_host: false, log_application: false, log_environment: false) }
+
+        def build_log(instance_tags: [], instance_named_tags: {}, tags: [], named_tags: {})
+          log = SemanticLogger::Log.new("TagMergingTest", :info, nil, instance_tags, instance_named_tags)
+          log.time = log_time
+          log.tags = tags unless tags.empty?
+          log.named_tags = named_tags unless named_tags.empty?
+          log
+        end
+
+        describe "positional tags" do
+          it "omits tags key when no tags present" do
+            log = build_log
+
+            result = formatter.call(log, nil)
+
+            refute result.key?(:tags)
+          end
+
+          it "returns thread tags only" do
+            log = build_log(tags: %w[thread1 thread2])
+
+            result = formatter.call(log, nil)
+
+            assert_equal %w[thread1 thread2], result[:tags]
+          end
+
+          it "returns instance tags only" do
+            log = build_log(instance_tags: %w[instance1 instance2])
+
+            result = formatter.call(log, nil)
+
+            assert_equal %w[instance1 instance2], result[:tags]
+          end
+
+          it "concatenates thread tags before instance tags" do
+            log = build_log(
+              tags: %w[thread1 thread2],
+              instance_tags: %w[instance1 instance2]
+            )
+
+            result = formatter.call(log, nil)
+
+            assert_equal %w[thread1 thread2 instance1 instance2], result[:tags]
+          end
+
+          it "preserves duplicates when same tag in both sources" do
+            log = build_log(
+              tags: %w[shared unique-thread],
+              instance_tags: %w[shared unique-instance]
+            )
+
+            result = formatter.call(log, nil)
+
+            assert_equal %w[shared unique-thread shared unique-instance], result[:tags]
+          end
+        end
+
+        describe "named tags" do
+          it "omits named_tags key when no named tags present" do
+            log = build_log
+
+            result = formatter.call(log, nil)
+
+            refute result.key?(:named_tags)
+          end
+
+          it "returns thread named tags only" do
+            log = build_log(named_tags: {request_id: "123", user: "alice"})
+
+            result = formatter.call(log, nil)
+
+            assert_equal({request_id: "123", user: "alice"}, result[:named_tags])
+          end
+
+          it "returns instance named tags only" do
+            log = build_log(instance_named_tags: {service: "api", version: "2.0"})
+
+            result = formatter.call(log, nil)
+
+            assert_equal({service: "api", version: "2.0"}, result[:named_tags])
+          end
+
+          it "merges thread and instance named tags" do
+            log = build_log(
+              named_tags: {request_id: "123"},
+              instance_named_tags: {service: "api"}
+            )
+
+            result = formatter.call(log, nil)
+
+            assert_equal({request_id: "123", service: "api"}, result[:named_tags])
+          end
+
+          it "instance named tags override thread named tags on conflict" do
+            log = build_log(
+              named_tags: {user: "thread-user", request_id: "123"},
+              instance_named_tags: {user: "instance-user", service: "api"}
+            )
+
+            result = formatter.call(log, nil)
+
+            assert_equal({user: "instance-user", request_id: "123", service: "api"}, result[:named_tags])
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/tag_merging/signalfx_test.rb
+++ b/test/tag_merging/signalfx_test.rb
@@ -1,0 +1,93 @@
+require_relative "../test_helper"
+require "json"
+
+module SemanticLogger
+  module Formatters
+    class SignalfxTagMergingTest < Minitest::Test
+      MOCK_LOGGER = Struct.new(:host, :application, :environment)
+
+      describe "Signalfx formatter tag merging" do
+        let(:log_time) { Time.utc(2017, 1, 14, 8, 32, 5.375276) }
+        let(:formatter) do
+          SemanticLogger::Formatters::Signalfx.new(
+            token: "test-token",
+            dimensions: %i[user request_id service],
+            log_host: false,
+            log_application: false,
+            log_environment: false
+          )
+        end
+        let(:logger) { MOCK_LOGGER.new("test_host", "test_app", "test") }
+
+        def build_log(instance_tags: [], instance_named_tags: {}, tags: [], named_tags: {})
+          log = SemanticLogger::Log.new("TagMergingTest", :info, nil, instance_tags, instance_named_tags)
+          log.time = log_time
+          log.metric = "/test/metric"
+          log.tags = tags unless tags.empty?
+          log.named_tags = named_tags unless named_tags.empty?
+          log
+        end
+
+        def dimensions(log)
+          result = JSON.parse(formatter.call(log, logger))
+          result["counter"].first["dimensions"]
+        end
+
+        describe "named tags as dimensions" do
+          it "excludes dimensions when no named tags present" do
+            log = build_log
+
+            dims = dimensions(log)
+
+            refute dims.key?("user")
+            refute dims.key?("request_id")
+            refute dims.key?("service")
+          end
+
+          it "includes thread named tags matching dimensions" do
+            log = build_log(named_tags: {request_id: "123", user: "alice"})
+
+            dims = dimensions(log)
+
+            assert_equal "123", dims["request_id"]
+            assert_equal "alice", dims["user"]
+          end
+
+          it "includes instance named tags matching dimensions" do
+            log = build_log(instance_named_tags: {service: "api", user: "bob"})
+
+            dims = dimensions(log)
+
+            assert_equal "api", dims["service"]
+            assert_equal "bob", dims["user"]
+          end
+
+          it "merges thread and instance named tags as dimensions" do
+            log = build_log(
+              named_tags: {request_id: "123"},
+              instance_named_tags: {service: "api"}
+            )
+
+            dims = dimensions(log)
+
+            assert_equal "123", dims["request_id"]
+            assert_equal "api", dims["service"]
+          end
+
+          it "instance named tags override thread named tags on conflict" do
+            log = build_log(
+              named_tags: {user: "thread-user", request_id: "123"},
+              instance_named_tags: {user: "instance-user", service: "api"}
+            )
+
+            dims = dimensions(log)
+
+            assert_equal "instance-user", dims["user"]
+            assert_equal "123", dims["request_id"]
+            assert_equal "api", dims["service"]
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/tag_merging_test.rb
+++ b/test/tag_merging_test.rb
@@ -1,0 +1,151 @@
+require_relative "test_helper"
+
+# Tests for tag merging behavior as documented in TAG_MERGING.md
+class TagMergingTest < Minitest::Test
+  describe "Tag Merging" do
+    let(:logger) { SemanticLogger::Test::CaptureLogEvents.new }
+
+    describe "1. Root Logger Cases" do
+      describe "1.1 No context" do
+        it "logs with empty tags" do
+          logger.info("Hello")
+
+          log = logger.events.first
+
+          assert_equal [], log.tags
+          assert_equal({}, log.named_tags)
+          assert_equal [], log.instance_tags
+          assert_equal({}, log.instance_named_tags)
+        end
+      end
+
+      describe "1.2 With thread tags" do
+        it "logs with thread tags from tagged block" do
+          logger.tagged("request-123", user: "alice") do
+            logger.info("Hello")
+          end
+
+          log = logger.events.first
+
+          assert_equal ["request-123"], log.tags
+          assert_equal({user: "alice"}, log.named_tags)
+          assert_equal [], log.instance_tags
+          assert_equal({}, log.instance_named_tags)
+        end
+      end
+    end
+
+    describe "2. Child Logger Cases (No Thread Context)" do
+      describe "2.1 With instance tags" do
+        it "logs with instance tags" do
+          child = logger.tagged("service-a", version: "2.0")
+
+          child.info("Hello")
+
+          log = child.events.first
+
+          assert_equal [], log.tags
+          assert_equal({}, log.named_tags)
+          assert_equal ["service-a"], log.instance_tags
+          assert_equal({version: "2.0"}, log.instance_named_tags)
+        end
+      end
+    end
+
+    describe "3. Child Logger with Thread Context (Independent)" do
+      describe "3.1 Instance tags + thread tags (via root)" do
+        it "combines thread tags with instance tags" do
+          child = logger.tagged("instance-pos", service: "api")
+
+          logger.tagged("thread-pos", request_id: "123") do
+            child.info("Hello")
+          end
+
+          log = child.events.first
+
+          assert_equal ["thread-pos"], log.tags
+          assert_equal({request_id: "123"}, log.named_tags)
+          assert_equal ["instance-pos"], log.instance_tags
+          assert_equal({service: "api"}, log.instance_named_tags)
+        end
+
+      end
+    end
+
+    describe "4. Child Logger Inside Own Tagged Block" do
+      describe "4.1 Instance tags + own block tags" do
+        it "duplicates instance tags in thread tags when child calls tagged with block" do
+          child = logger.tagged("instance-pos", service: "api")
+
+          child.tagged("block-pos", request_id: "123") do
+            child.info("Hello")
+          end
+
+          log = child.events.first
+
+          assert_equal ["instance-pos", "block-pos"], log.tags
+          assert_equal({service: "api", request_id: "123"}, log.named_tags)
+          assert_equal ["instance-pos"], log.instance_tags
+          assert_equal({service: "api"}, log.instance_named_tags)
+        end
+
+      end
+    end
+
+    describe "5. Nested Child Loggers" do
+      describe "5.1 Child of child logger" do
+        it "accumulates instance tags through child chain" do
+          child1 = logger.tagged("level-1")
+          child2 = child1.tagged("level-2")
+
+          child2.info("Hello")
+
+          log = child2.events.first
+
+          assert_equal [], log.tags
+          assert_equal({}, log.named_tags)
+          assert_equal ["level-1", "level-2"], log.instance_tags
+          assert_equal({}, log.instance_named_tags)
+        end
+
+      end
+
+      describe "5.2 Child logger inside another child's tagged block" do
+        it "combines thread tags from one child with instance tags from another" do
+          child1 = logger.tagged("child1-tag", service: "api")
+          child2 = logger.tagged("child2-tag", component: "worker")
+
+          child1.tagged("block-tag", request_id: "123") do
+            child2.info("Hello")
+          end
+
+          log = child2.events.first
+
+          assert_equal ["child1-tag", "block-tag"], log.tags
+          assert_equal({service: "api", request_id: "123"}, log.named_tags)
+          assert_equal ["child2-tag"], log.instance_tags
+          assert_equal({component: "worker"}, log.instance_named_tags)
+        end
+
+      end
+    end
+
+    describe "6. Edge Cases" do
+      describe "6.1 Named tag key conflicts" do
+        it "stores conflicting named tags separately in log fields" do
+          child = logger.tagged(user: "instance-user")
+
+          child.tagged(user: "block-user") do
+            child.info("Hello")
+          end
+
+          log = child.events.first
+
+          assert_equal({user: "block-user"}, log.named_tags)
+          assert_equal({user: "instance-user"}, log.instance_named_tags)
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Issue #165

### Changelog

- Add child logger with instance named tags support

### Description of changes

A new method is added called `child` which creates a copy of the current logger and sets _instance named tags_ on the logger. These tags will be included with every log message output by the child logger.
**Differently from named_tags, these tags are strictly tied to the logger instance, not to thread variables**. This allows creating multiple nested loggers to achieve logging of complex structured data, while keeping the code simple. An example of this could be:

```ruby
def create
  clogger = logger.child(user_id: user.id, flight_id: @flight.id)
  result_id = create_some_stuff
  clogger.debug("Created successfully", id: result_id)
rescue => err
  clogger.error("Bad failure", err: err.message)
end
```

### Name Alternatives

I personally don't love the name `child` for this method, I followed what [Ougai](https://github.com/tilfin/ougai?tab=readme-ov-file#create-a-child-logger) did. Some possibly better alternatives:
- `with_payload`
- `with_context`
- `with`

### Discussion Points

Thread named tags are treated separately and they could overlap with the message payload. I didn't want to touch/involve explicit interaction with thread named tags because it could cause a lot of confusion. I would go further and say that if instance named tags are used, thread named tags should be avoided, otherwise there are questions like:

```ruby
def create
  child_logger = logger.child(tag1: "bar")
  child_logger.tagged(tag1: "foo") do
    child_logger.info "Message"
  end
end
```

Should this code output `tag1: "foo"` or `tag1: "bar"`? I don't think there is a clear answer for this.
    

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
