### PR TITLE
Add high priority fields to beginning of JSON object when json format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   Ensures every attribute value is OTLP‑compatible.
 - Fix missing trace.id/span.id in NewRelic logs
 - Fix opentelemetry-logs-sdk logger does not expose logger_provider, causing NoMethodError on flush/close.
+- Add high priority fields (timestamp, level, level index and message) to beginning of JSON object output when using JSON formatter to ensure log entries are parsable even when JSON logs are mangled
 
 ## [4.17.0]
 

--- a/lib/semantic_logger/formatters/raw.rb
+++ b/lib/semantic_logger/formatters/raw.rb
@@ -117,11 +117,12 @@ module SemanticLogger
         self.log    = log
         self.logger = logger
 
+        time
+        level
+        message
         host
         application
         environment
-        time
-        level
         pid
         thread_name
         file_name_and_line
@@ -129,7 +130,6 @@ module SemanticLogger
         tags
         named_tags
         name
-        message
         payload
         exception
         metric

--- a/test/formatters/json_test.rb
+++ b/test/formatters/json_test.rb
@@ -1,0 +1,45 @@
+require_relative "../test_helper"
+
+module SemanticLogger
+  module Formatters
+    class JsonTest < Minitest::Test
+      describe Json do
+        let(:log_time) do
+          Time.utc(2017, 1, 14, 8, 32, 5.375276)
+        end
+
+        let(:level) do
+          :debug
+        end
+
+        let(:log) do
+          log      = SemanticLogger::Log.new("JsonTest", level)
+          log.time = log_time
+          log
+        end
+
+        let(:expected_time) do
+          SemanticLogger::Formatters::Base::PRECISION == 3 ? "2017-01-14T08:32:05.375Z" : "2017-01-14T08:32:05.375276Z"
+        end
+
+        let(:formatter) do
+          formatter = SemanticLogger::Formatters::Json.new(log_host: false)
+          # Does not use the logger instance for formatting purposes
+          formatter.call(log, nil)
+          formatter
+        end
+
+        describe "call" do
+          it "sets timestamp, level, level_index, and message at the beginning of the JSON object" do
+            log.message = "Some message"
+            expected_start = %({"timestamp":"#{expected_time}","level":"debug","level_index":1,"message":"Some message")
+
+            is_starting_with_high_priority_fields = formatter.call(log, nil).start_with?(expected_start)
+
+            assert is_starting_with_high_priority_fields, "Expected #{formatter.call(log, nil)} to start with #{expected_start}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Issue # (if available)

N/A

### Changelog

Pull requests will not be accepted without a description of this change under the `[unreleased]` section 
in the file `CHANGELOG`.

### Description of changes

This PR moves the timestamp, level, level_index and message to the beginning of the JSON object.
This was a request by our DevOps team so that in case something is wrong with the JSON output and something is being "mangled" at the end of the log line, it is possible to extract timestamp, level and message from the information using regex or in general, simple tools.

This change shouldn't break anything since order of JSON shouldn't matter for any programmatic tools, but it does change for humans.

Would you be open to this kind of change?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
