### PR TITLE
Fix opentelemetry-logs-sdk logger does not expose logger_provider, causing NoMethodError on flush/close.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Fix opentelemetry-logs-sdk logger does not expose logger_provider, causing NoMethodError on flush/close.
+
 ## [4.17.0]
 
 - Correct `source_code_uri` URL


### PR DESCRIPTION
Prevents NoMethodError on exit when flushing/closing the OpenTelemetry appender.

```log
SemanticLogger::Appenders 
-- Failed to flush appender: SemanticLogger::Appender::OpenTelemetry 
-- Exception: NoMethodError: undefined method 
  `logger_provider' for #<OpenTelemetry::SDK::Logs::Logger:0x00007f777ed1cc28 
    @instrumentation_scope=#<struct OpenTelemetry::SDK::InstrumentationScope name="...", version="...">, 
    @logger_provider=#<OpenTelemetry::SDK::Logs::LoggerProvider:0x00007f777f00ca50 
    @log_record_processors=[#<OpenTelemetry::SDK::Logs::Export::BatchLogRecordProcessor:0x00007f777f013760 
    @exporter=#<OpenTelemetry::Exporter::OTLP::Logs::LogsExporter:0x00007f777f00c898 @uri=#<URI::HTTPS ...>, 
    @http=#<Net::HTTP ... open=true>, @path="/v1/logs", 
    @headers={"User-Agent"=>"OTel-OTLP-Exporter-Ruby/0.2.0 Ruby/3.1.6 (x86_64-linux-musl; ruby/3.1.6)"}, 
    @timeout=10.0, @compression="gzip", @shutdown=false>, @exporter_timeout_seconds=30.0, 
    @mutex=#<Thread::Mutex:0x00007f777f013508>, @export_mutex=#<Thread::Mutex:0x00007f777f0134b8>, 
    @condition=#<Thread::ConditionVariable:0x00007f777f013468>, @keep_running=true, @stopped=false, 
    @delay_seconds=1.0, @max_queue_size=2048, @batch_size=512, @log_records=[], @pid=27, 
    @thread=#<Thread:0x00007f777f013378 /app/vendor/bundle/ruby/3.1.0/gems/newrelic_rpm-9.21.0/lib/new_relic/agent/tracer.rb:424 sleep>>], 
    @log_record_limits=#<OpenTelemetry::SDK::Logs::LogRecordLimits:0x00007f777a2f2f08 @attribute_count_limit=128, 
    @attribute_length_limit=nil>, 
    @mutex=#<Thread::Mutex:0x00007f777f00c9b0>, @resource=#<OpenTelemetry::SDK::Resources::Resource:0x00007f777f092e20 
    @attributes={"service.name"=>"...", "service.namespace"=>"...", "service.version"=>"...", 
    "deployment.environment"=>"staging"}, 
    @attribute_enumerator=#<Enumerator: {"service.name"=>"...", "service.namespace"=>"...", 
    "service.version"=>"...", "deployment.environment"=>"staging"}:each>>, @stopped=false, 
    @registry={#<struct OpenTelemetry::SDK::Logs::LoggerProvider::Key name="...", 
    version="...">=>#<OpenTelemetry::SDK::Logs::Logger:0x00007f777ed1cc28 ...>},
    @registry_mutex=#<Thread::Mutex:0x00007f777f00c938>>>
```

### Motivation / Background

This PR fixes a crash observed during process shutdown caused by a NoMethodError raised when attempting to access a logger provider from the OpenTelemetry Logger instance. The opentelemetry-logs-sdk Logger implementation does not expose the expected api in some versions, which caused flush/close code paths to call a method that does not exist and surface noisy exceptions at shutdown. The change prevents those exceptions and ensures graceful flushing/shutdown of the OpenTelemetry appender.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.