### PR TITLE
Add `logger` as a runtime dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Add `logger` as a runtime dep
+
 ## [4.17.0]
 
 - Correct `source_code_uri` URL
@@ -15,7 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add appender for Open Telemetry Logs
 - NR Integration: Ensures key/values are not nested under `messages`
 - NR Integration: Ensures structures are built for all nested json (I.E build an actual object instead of doing `span.id` as the key)
-- NR Integration: Named tags will instead be added directly to the JSON.  `named_tags` now adds key value pairs to object instead of nesting.  
+- NR Integration: Named tags will instead be added directly to the JSON.  `named_tags` now adds key value pairs to object instead of nesting.
 - NR Integration: Conflicts between `named_tags` and existing tags are logged to `named_tag_conflicts` key.
 - NR Integration: Adds a quick and hacky Dockerfile and Docker Compose file to allow for testing changes locally.
 

--- a/semantic_logger.gemspec
+++ b/semantic_logger.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.license               = "Apache-2.0"
   s.required_ruby_version = ">= 2.7"
   s.add_dependency "concurrent-ruby", "~> 1.0"
+  s.add_dependency "logger", "~> 1.7"
   s.metadata = {
     "bug_tracker_uri"       => "https://github.com/reidmorrison/semantic_logger/issues",
     "documentation_uri"     => "https://logger.rocketjob.io",


### PR DESCRIPTION
### Issue # (if available)

Got following warning when running on ruby 3.4.5

```
/home/johndoe/.local/share/asdf/installs/ruby/3.4.5/lib/ruby/gems/3.4.0/gems/semantic_logger-4.17.0/lib/semantic_logger/levels.rb:1: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```

### Changelog

- [x] Pull requests will not be accepted without a description of this change under the `[unreleased]` section in the file `CHANGELOG`.

### Description of changes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
