### PR TITLE
Change on_worker_boot to before_worker_boot for config/puma.rb in docs

### DIFF
--- a/docs/forking.md
+++ b/docs/forking.md
@@ -32,7 +32,7 @@ add the following to your worker boot code:
 
 ~~~ruby
 # config/puma.rb
-on_worker_boot do
+before_worker_boot do
   # Re-open appenders after forking the process
   SemanticLogger.reopen
 end


### PR DESCRIPTION
In puma 7.0.0 callback hooks were renamed, on_worker_boot was renamed to before_worker_boot.

https://github.com/puma/puma/blob/master/History.md#700--2025-09-03
https://github.com/puma/puma/pull/3438
