### PR TITLE
Add event_type to Honeybadger Insights payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix missing trace.id/span.id in NewRelic logs
 - Fix opentelemetry-logs-sdk logger does not expose logger_provider, causing NoMethodError on flush/close.
 - Fix invalid exception instance causing NoMethodError when retrieving backtrace
+- Add event_type to Honeybadger Insights payloads
 
 ## [4.17.0]
 

--- a/lib/semantic_logger/appender/honeybadger_insights.rb
+++ b/lib/semantic_logger/appender/honeybadger_insights.rb
@@ -43,7 +43,7 @@ module SemanticLogger
 
       # Send log to honeybadger events API
       def log(log)
-        event = formatter.call(log, self)
+        event = formatter.call(log, self).merge(event_type: "log")
 
         ::Honeybadger.event(event)
 

--- a/test/appender/honeybadger_insights_test.rb
+++ b/test/appender/honeybadger_insights_test.rb
@@ -20,6 +20,15 @@ module Appender
           assert_equal @message, hash[:message]
           assert_equal level, hash[:level]
         end
+
+        it "includes an event_type of 'log' in the notification" do
+          hash = nil
+          Honeybadger.stub(:event, ->(h) { hash = h }) do
+            @appender.send(level, @message)
+          end
+
+          assert_equal "log", hash[:event_type]
+        end
       end
 
       it "send notification to Honeybadger with custom attributes" do


### PR DESCRIPTION
### Description of changes

Honeybadger customers using SemanticLogger have found that it would be helpful if we used `event_type` to identify the events being sent via SemanticLogger, since we use this field heavily for filtering in queries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
