### PR TITLE
Pin minitest < 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix missing trace.id/span.id in NewRelic logs
 - Fix opentelemetry-logs-sdk logger does not expose logger_provider, causing NoMethodError on flush/close.
 - Fix invalid exception instance causing NoMethodError when retrieving backtrace
+- Pin minitest to < 6.0 to avoid breaking changes
 
 ## [4.17.0]
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "amazing_print"
-gem "minitest"
+gem "minitest", "< 6.0"
 gem "minitest-reporters"
 gem "minitest-shared_description"
 gem "minitest-stub_any_instance"


### PR DESCRIPTION
While working on #331, I found that I couldn't run the tests from a clean clone. Claude came up with this:

    So the root cause is minitest 6.0.2 introducing multiple breaking changes:

    1. class_name is now abstract on Minitest::Runnable
    2. stub no longer works on arbitrary objects — The test suite extensively uses .stub on object instances (e.g., Net::TCPClient, SemanticLogger), which minitest 6.0 no longer supports.

This was a faster solution than updating all the tests to work with the latest minitest. :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
