### PR TITLE
Add `with_level` method to `Base` to allow changing log level during block execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix missing trace.id/span.id in NewRelic logs
 - Fix opentelemetry-logs-sdk logger does not expose logger_provider, causing NoMethodError on flush/close.
 - Fix invalid exception instance causing NoMethodError when retrieving backtrace
+- Pin minitest to < 6.0 to avoid breaking changes
+- Add `with_level` method to `Base` to allow changing log level during block execution, in analogue to `Logger.with_level`.
 
 ## [4.17.0]
 
@@ -21,7 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add appender for Open Telemetry Logs
 - NR Integration: Ensures key/values are not nested under `messages`
 - NR Integration: Ensures structures are built for all nested json (I.E build an actual object instead of doing `span.id` as the key)
-- NR Integration: Named tags will instead be added directly to the JSON.  `named_tags` now adds key value pairs to object instead of nesting.  
+- NR Integration: Named tags will instead be added directly to the JSON.  `named_tags` now adds key value pairs to object instead of nesting.
 - NR Integration: Conflicts between `named_tags` and existing tags are logged to `named_tag_conflicts` key.
 - NR Integration: Adds a quick and hacky Dockerfile and Docker Compose file to allow for testing changes locally.
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "amazing_print"
-gem "minitest"
+gem "minitest", "< 6.0"
 gem "minitest-reporters"
 gem "minitest-shared_description"
 gem "minitest-stub_any_instance"

--- a/lib/semantic_logger/base.rb
+++ b/lib/semantic_logger/base.rb
@@ -34,6 +34,19 @@ module SemanticLogger
       @level || SemanticLogger.default_level
     end
 
+    # Set the logging level for this logger during the execution of the given block
+    #
+    # Refer to the documentation for `#level=` for more information about the possible log levels.
+    def with_level(new_level)
+      old_level = level
+
+      self.level = new_level
+
+      yield
+    ensure
+      self.level = old_level
+    end
+
     # Implement the log level calls
     #   logger.debug(message, hash|exception=nil, &block)
     #

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -64,6 +64,33 @@ class LoggerTest < Minitest::Test
       end
     end
 
+    describe "#with_level" do
+      it "temporarily changes logging level during the execution of the given block" do
+        logger.level = :error
+
+        assert_equal :error, logger.level
+
+        logger.debug("not logged")
+
+        logger.with_level(:debug) do
+          assert_equal :debug, logger.level
+
+          logger.debug("logged")
+        end
+
+        assert_equal :error, logger.level
+
+        events = logger.events
+
+        assert_equal 1, events.size
+
+        event = events.first
+
+        assert_equal "logged", event.message
+        assert_equal :debug, event.level
+      end
+    end
+
     describe "#level?" do
       it "return true for debug? with :trace level" do
         logger.level = :trace


### PR DESCRIPTION
In analogue to `Logger.with_level`.

### Issue # (if available)

https://github.com/reidmorrison/semantic_logger/issues/334

### Changelog

Pull requests will not be accepted without a description of this change under the `[unreleased]` section 
in the file `CHANGELOG`.

### Description of changes

The base `Logger` class offers a `with_level` method which allows changing the logging level during block execution: https://www.rubydoc.info/gems/logger/1.7.0/Logger:with_level. Sidekiq 8.0 makes use of this method, which means that `rails_semantic_logger` (which replaces the Sidekiq logger with a `SemanticLogger::Logger`) breaks when this method is called: https://github.com/sidekiq/sidekiq/commit/90f83226d893424382aba3f24073ce89f4b93c2e.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
