### PR TITLE
Fix ArgumentError in CaptureLogEvents#batch

### DIFF
--- a/lib/semantic_logger/test/capture_log_events.rb
+++ b/lib/semantic_logger/test/capture_log_events.rb
@@ -34,8 +34,8 @@ module SemanticLogger
       end
 
       # Supports batching of log events
-      def batch(_logs)
-        @events += log
+      def batch(logs)
+        @events += logs
       end
 
       def clear


### PR DESCRIPTION
## Summary

Fixes #327

`CaptureLogEvents#batch` referenced the `log` instance method instead of the parameter, causing `ArgumentError: wrong number of arguments (given 0, expected 1)` when used as a processor with `AsyncBatch`.

## Changes

- `log` → `logs` — fix the incorrect method reference to use the parameter
- `_logs` → `logs` — remove the underscore prefix since the parameter is actually used