### PR TITLE
Fix ArgumentError in CaptureLogEvents#batch (#327)

### DIFF
--- a/lib/semantic_logger/test/capture_log_events.rb
+++ b/lib/semantic_logger/test/capture_log_events.rb
@@ -34,8 +34,8 @@ module SemanticLogger
       end
 
       # Supports batching of log events
-      def batch(_logs)
-        @events += log
+      def batch(logs)
+        logs.each { |log| self.log(log) }
       end
 
       def clear

--- a/test/test/capture_log_events_test.rb
+++ b/test/test/capture_log_events_test.rb
@@ -46,5 +46,18 @@ class CaptureLogEventsTest < Minitest::Test
 
       assert_equal(0, capture_logger.events.size)
     end
+
+    it "captures a batch of log events" do
+      logs = %w[first second].map do |message|
+        log         = SemanticLogger::Log.new("Test", :info)
+        log.message = message
+        log
+      end
+
+      capture_logger.batch(logs)
+
+      assert_equal %w[first second], capture_logger.events.map(&:message)
+      assert_equal %i[info info], capture_logger.events.map(&:level)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #327.

`SemanticLogger::Test::CaptureLogEvents#batch` referenced `log` (the instance method) instead of its `logs` argument:

```ruby
def batch(_logs)
  @events += log   # calls the `log` method with 0 args
end
```

Ruby resolved `log` to the `log(log)` method and called it with zero arguments, raising `ArgumentError: wrong number of arguments (given 0, expected 1)`. When this test appender is wrapped in an `AsyncBatch` proxy, the background thread crashes and restarts in a loop on every batch flush.

## Fix

Route each batched event through `#log` so `Logger.call_subscribers` still fires, consistent with the single-event path:

```ruby
def batch(logs)
  logs.each { |log| self.log(log) }
end
```

## Test

Added a regression test that builds `Log` objects and passes them through `batch`, asserting messages and levels are captured. This path was previously untested, which is why the typo went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)