### PR TITLE
Add non-blocking (drop) mode to async appenders

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -176,6 +176,40 @@ concurrent threads simply enqueue events, and each appender writes them out sequ
 correct order. For the rare cases where you want logging to happen inline on the calling thread,
 see [Synchronous Operation](api.html#synchronous-operation).
 
+### Non-blocking (dropping) mode
+
+By default the in-memory queue is capped (`max_queue_size`, default `10,000`). When the queue is
+full, for example because an appender cannot keep up, calls to `logger.info` block until space
+becomes available. This guarantees no log message is lost, at the cost of (briefly) slowing down
+the application.
+
+For workloads where application availability matters more than complete logs, enable
+`non_blocking` so that log messages are dropped instead of blocking the calling thread once the
+queue is full:
+
+~~~ruby
+SemanticLogger.add_appender(
+  file_name:    "production.log",
+  async:        true,
+  non_blocking: true
+)
+~~~
+
+When messages are dropped, the count is logged to the internal logger at most once every
+`dropped_message_report_seconds` (default `30`) so that dropped messages do not go unnoticed:
+
+~~~ruby
+SemanticLogger.add_appender(
+  file_name:                      "production.log",
+  async:                          true,
+  non_blocking:                   true,
+  dropped_message_report_seconds: 60
+)
+~~~
+
+`non_blocking` only applies to a capped queue; an uncapped queue (`max_queue_size: -1`) never
+blocks and never drops, but can grow without bound.
+
 ### Ruby Support
 
 For the complete list of supported Ruby versions, see

--- a/lib/semantic_logger/appender.rb
+++ b/lib/semantic_logger/appender.rb
@@ -34,6 +34,7 @@ module SemanticLogger
     def self.factory(async: false, batch: nil,
                      max_queue_size: 10_000, lag_check_interval: 1_000, lag_threshold_s: 30,
                      batch_size: 300, batch_seconds: 5,
+                     non_blocking: false, dropped_message_report_seconds: 30,
                      **args,
                      &)
       appender = build(**args, &)
@@ -43,18 +44,22 @@ module SemanticLogger
 
       if batch == true
         Appender::AsyncBatch.new(
-          appender:        appender,
-          max_queue_size:  max_queue_size,
-          lag_threshold_s: lag_threshold_s,
-          batch_size:      batch_size,
-          batch_seconds:   batch_seconds
+          appender:                       appender,
+          max_queue_size:                 max_queue_size,
+          lag_threshold_s:                lag_threshold_s,
+          batch_size:                     batch_size,
+          batch_seconds:                  batch_seconds,
+          non_blocking:                   non_blocking,
+          dropped_message_report_seconds: dropped_message_report_seconds
         )
       elsif async == true
         Appender::Async.new(
-          appender:           appender,
-          max_queue_size:     max_queue_size,
-          lag_check_interval: lag_check_interval,
-          lag_threshold_s:    lag_threshold_s
+          appender:                       appender,
+          max_queue_size:                 max_queue_size,
+          lag_check_interval:             lag_check_interval,
+          lag_threshold_s:                lag_threshold_s,
+          non_blocking:                   non_blocking,
+          dropped_message_report_seconds: dropped_message_report_seconds
         )
       else
         appender

--- a/lib/semantic_logger/appender/async.rb
+++ b/lib/semantic_logger/appender/async.rb
@@ -6,8 +6,8 @@ module SemanticLogger
     class Async
       extend Forwardable
 
-      attr_accessor :lag_check_interval, :lag_threshold_s
-      attr_reader :queue, :appender, :max_queue_size
+      attr_accessor :lag_check_interval, :lag_threshold_s, :dropped_message_report_seconds
+      attr_reader :queue, :appender, :max_queue_size, :non_blocking
 
       # Forward methods that can be called directly
       def_delegator :@appender, :name
@@ -36,15 +36,34 @@ module SemanticLogger
       #   lag_check_interval: [Integer]
       #     Number of messages to process before checking for slow logging.
       #     Default: 1,000
+      #
+      #   non_blocking: [true|false]
+      #     Whether to drop log messages instead of blocking the calling thread when the queue is full.
+      #     When true and the queue is capped, attempts to add to a full queue return immediately and
+      #     the message is dropped. The number of dropped messages is logged to the internal logger
+      #     periodically (see dropped_message_report_seconds). Only applies to a capped queue.
+      #     Default: false
+      #
+      #   dropped_message_report_seconds: [Integer]
+      #     When non_blocking is enabled, log the count of dropped messages to the internal logger
+      #     at most once every this number of seconds.
+      #     Default: 30
       def initialize(appender:,
                      max_queue_size: 10_000,
                      lag_check_interval: 1_000,
-                     lag_threshold_s: 30)
-        @appender           = appender
-        @lag_check_interval = lag_check_interval
-        @lag_threshold_s    = lag_threshold_s
-        @thread             = nil
-        @max_queue_size     = max_queue_size
+                     lag_threshold_s: 30,
+                     non_blocking: false,
+                     dropped_message_report_seconds: 30)
+        @appender                       = appender
+        @lag_check_interval             = lag_check_interval
+        @lag_threshold_s                = lag_threshold_s
+        @thread                         = nil
+        @max_queue_size                 = max_queue_size
+        @non_blocking                   = non_blocking
+        @dropped_message_report_seconds = dropped_message_report_seconds
+        @dropped_message_count          = 0
+        @dropped_message_reported_at    = Time.now
+        @dropped_message_mutex          = Mutex.new
         create_queue
         thread
       end
@@ -67,6 +86,12 @@ module SemanticLogger
         @capped
       end
 
+      # Returns [true|false] whether messages are dropped instead of blocking when the queue is full.
+      # Only a capped queue can drop messages.
+      def non_blocking?
+        @non_blocking && capped?
+      end
+
       # Returns [Thread] the worker thread.
       #
       # Starts the worker thread if not running.
@@ -82,8 +107,19 @@ module SemanticLogger
       end
 
       # Add log message for processing.
+      #
+      # When non-blocking and the queue is full, the message is dropped instead of blocking the
+      # calling thread, and the count of dropped messages is reported periodically.
       def log(log)
-        queue << log
+        if non_blocking?
+          begin
+            queue.push(log, true)
+          rescue ThreadError
+            message_dropped
+          end
+        else
+          queue << log
+        end
       end
 
       # Flush all queued log entries disk, database, etc.
@@ -176,6 +212,24 @@ module SemanticLogger
           logger.warn "Async: Appender thread: Ignoring unknown command: #{message[:command]}"
         end
         true
+      end
+
+      # Record a dropped message, reporting the running count to the internal logger at most
+      # once every dropped_message_report_seconds.
+      def message_dropped
+        @dropped_message_mutex.synchronize do
+          @dropped_message_count += 1
+          diff = Time.now - @dropped_message_reported_at
+          return if diff < dropped_message_report_seconds
+
+          logger.warn(
+            "Async: Dropped #{@dropped_message_count} log messages in the last #{diff.round} seconds. " \
+            "The queue is full (max_queue_size: #{max_queue_size}). " \
+            "Consider reducing the log level, increasing max_queue_size, or changing the appenders"
+          )
+          @dropped_message_count       = 0
+          @dropped_message_reported_at = Time.now
+        end
       end
 
       def check_lag(log)

--- a/lib/semantic_logger/appender/async_batch.rb
+++ b/lib/semantic_logger/appender/async_batch.rb
@@ -29,14 +29,18 @@ module SemanticLogger
                      max_queue_size: 10_000,
                      lag_threshold_s: 30,
                      batch_size: 300,
-                     batch_seconds: 5)
+                     batch_seconds: 5,
+                     non_blocking: false,
+                     dropped_message_report_seconds: 30)
         @batch_size    = batch_size
         @batch_seconds = batch_seconds
         @signal        = Concurrent::Event.new
         super(
-          appender:        appender,
-          max_queue_size:  max_queue_size,
-          lag_threshold_s: lag_threshold_s
+          appender:                       appender,
+          max_queue_size:                 max_queue_size,
+          lag_threshold_s:                lag_threshold_s,
+          non_blocking:                   non_blocking,
+          dropped_message_report_seconds: dropped_message_report_seconds
         )
 
         return if appender.respond_to?(:batch)

--- a/test/appender/async_test.rb
+++ b/test/appender/async_test.rb
@@ -39,6 +39,79 @@ module Appender
           assert_instance_of Queue, added_appender.queue
         end
       end
+
+      describe "non_blocking" do
+        # Records warnings logged to the internal logger.
+        let :recording_logger do
+          Class.new do
+            attr_reader :warnings
+
+            def initialize
+              @warnings = []
+            end
+
+            def warn(message)
+              @warnings << message
+            end
+
+            def trace(*)
+            end
+
+            def name
+              "Test"
+            end
+          end.new
+        end
+
+        it "is disabled by default" do
+          proxy = SemanticLogger::Appender::Async.new(appender: appender, max_queue_size: 2)
+
+          refute_predicate proxy, :non_blocking?
+        ensure
+          proxy&.close
+        end
+
+        it "cannot drop messages on an uncapped queue" do
+          proxy = SemanticLogger::Appender::Async.new(appender: appender, max_queue_size: -1, non_blocking: true)
+
+          refute_predicate proxy, :non_blocking?, "an uncapped queue cannot drop messages"
+        ensure
+          proxy&.close
+        end
+
+        it "drops messages instead of blocking when the queue is full" do
+          proxy = SemanticLogger::Appender::Async.new(
+            appender:                       appender,
+            max_queue_size:                 2,
+            non_blocking:                   true,
+            dropped_message_report_seconds: 0
+          )
+
+          assert_predicate proxy, :non_blocking?
+          proxy.logger = recording_logger
+
+          # Stop the worker thread so the queue is not drained while we fill it.
+          worker = proxy.instance_variable_get(:@thread)
+          worker.kill
+          worker.join
+
+          log = SemanticLogger::Log.new("Test", :info)
+          proxy.log(log) # queue size 1
+          proxy.log(log) # queue size 2 (full)
+
+          assert_equal 2, proxy.queue.size
+
+          # Further messages must be dropped, not block, and not raise.
+          proxy.log(log)
+          proxy.log(log)
+
+          assert_equal 2, proxy.queue.size, "queue must not grow beyond its cap"
+          refute_empty recording_logger.warnings
+          assert_match(/Dropped \d+ log messages/, recording_logger.warnings.last)
+        ensure
+          proxy&.queue&.clear
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #323

## Summary

Adds an opt-in **non-blocking (drop) mode** to the async/async_batch appender proxies. For workloads where application availability matters more than complete logs, log messages are dropped instead of blocking the calling thread once the capped queue is full.

- **Drops silently** on a full queue rather than blocking the caller or raising. Per the issue discussion, this avoids the cost of raising exceptions on the hot path.
- **Reports the dropped-message count** to the internal logger (which writes directly to `$stderr`, so the report itself can never be dropped) at most once every `dropped_message_report_seconds` (default `30`, configurable).
- **Defaults to current behavior** (`non_blocking: false`, i.e. blocking) so existing users are unaffected.
- Only applies to a capped queue; an uncapped queue (`max_queue_size: -1`) never blocks and never drops.

## Usage

```ruby
SemanticLogger.add_appender(
  file_name:                      "production.log",
  async:                          true,
  non_blocking:                   true,   # drop instead of block when the queue is full
  dropped_message_report_seconds: 60      # report dropped count at most every 60s (default 30)
)
```

## Changes

- `appender/async.rb`: new `non_blocking:` / `dropped_message_report_seconds:` params, a `non_blocking?` predicate, the drop path in `#log` (`queue.push(log, true)` rescuing `ThreadError`), and a mutex-guarded `message_dropped` reporter. Scoped to `#log` so `flush`/`close` commands still enqueue normally.
- `appender/async_batch.rb`: threads both options through to `super`.
- `appender.rb`: `Appender.factory` accepts and forwards both options to `Async` and `AsyncBatch`.
- `test/appender/async_test.rb`: tests for default-off, uncapped-can't-drop, and deterministic drop-on-full with a report emitted.
- `docs/index.md`: documents the new mode under "How it works".

## Testing

Full suite passes (`bundle exec rake test`): 1221 runs, 0 failures, 0 errors (MongoDB tests skipped, no instance running). `rubocop` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)