### PR TITLE
Allow separate stdout and stderr console appenders (#203)

### DIFF
--- a/docs/appenders.md
+++ b/docs/appenders.md
@@ -200,6 +200,26 @@ Semantic Logger can log data to any IO Stream instance, such as $stderr or $stdo
 SemanticLogger.add_appender(io: $stderr, level: :error)
 ~~~
 
+#### Splitting output across stdout and stderr
+
+A common operational pattern is to route lower severity messages to `$stdout` and
+warnings and errors to `$stderr`. Semantic Logger allows one appender per console
+stream, so a separate `$stdout` and `$stderr` appender can be added at the same time.
+Use `level:` and/or `filter:` to control what each one writes:
+
+~~~ruby
+stdout_filter = ->(log) { %i[trace debug info].include?(log.level) }
+
+# Informational messages to stdout:
+SemanticLogger.add_appender(io: $stdout, formatter: :color, level: :trace, filter: stdout_filter)
+
+# Warnings and above to stderr:
+SemanticLogger.add_appender(io: $stderr, formatter: :color, level: :warn)
+~~~
+
+Adding a second appender for a console stream that already has one is ignored (to
+avoid duplicate console output), but `$stdout` and `$stderr` are tracked separately.
+
 ### Syslog
 
 Log to a local Syslog daemon

--- a/lib/semantic_logger/appender/async.rb
+++ b/lib/semantic_logger/appender/async.rb
@@ -20,6 +20,8 @@ module SemanticLogger
       def_delegator :@appender, :level=
       def_delegator :@appender, :logger
       def_delegator :@appender, :logger=
+      def_delegator :@appender, :console_stream
+      def_delegator :@appender, :console_output?
 
       # Appender proxy to allow an existing appender to run asynchronously in a separate thread.
       #

--- a/lib/semantic_logger/appender/io.rb
+++ b/lib/semantic_logger/appender/io.rb
@@ -60,8 +60,12 @@ module SemanticLogger
         @io.flush if @io.respond_to?(:flush)
       end
 
-      def console_output?
-        [$stderr, $stdout].include?(@io)
+      def console_stream
+        if @io.equal?($stdout)
+          :stdout
+        elsif @io.equal?($stderr)
+          :stderr
+        end
       end
     end
   end

--- a/lib/semantic_logger/appenders.rb
+++ b/lib/semantic_logger/appenders.rb
@@ -12,8 +12,9 @@ module SemanticLogger
     def add(**args, &)
       appender = SemanticLogger::Appender.factory(**args, &)
 
-      if appender.respond_to?(:console_output?) && appender.console_output? && console_output?
-        logger.warn "Ignoring attempt to add a second console appender: #{appender.class.name} since it would result in duplicate console output."
+      stream = appender.respond_to?(:console_stream) && appender.console_stream
+      if stream && console_streams.include?(stream)
+        logger.warn "Ignoring attempt to add a second #{stream} console appender since it would result in duplicate console output."
         return
       end
 
@@ -21,10 +22,15 @@ module SemanticLogger
       appender
     end
 
+    # The console streams (:stdout and/or :stderr) already being written to by the existing appenders.
+    def console_streams
+      filter_map { |appender| appender.console_stream if appender.respond_to?(:console_stream) }
+    end
+
     # Whether any of the existing appenders already output to the console?
     # I.e. Writes to stdout or stderr.
     def console_output?
-      any? { |appender| appender.respond_to?(:console_output?) && appender.console_output? }
+      console_streams.any?
     end
 
     def log(log)

--- a/lib/semantic_logger/subscriber.rb
+++ b/lib/semantic_logger/subscriber.rb
@@ -73,9 +73,15 @@ module SemanticLogger
       super && (log.metric_only? ? metrics? : true)
     end
 
-    # Whether this appender is logging to stdout or stderror
+    # The console stream this appender writes to, if any.
+    # Returns one of :stdout, :stderr, or nil when not writing to a console stream.
+    def console_stream
+      nil
+    end
+
+    # Whether this appender is logging to stdout or stderr.
     def console_output?
-      false
+      !console_stream.nil?
     end
 
     private

--- a/test/appender/io_test.rb
+++ b/test/appender/io_test.rb
@@ -50,6 +50,27 @@ module Appender
           refute_predicate appender, :console_output?
         end
       end
+
+      describe "#console_stream" do
+        it "is :stdout when writing to stdout" do
+          appender = SemanticLogger::Appender::IO.new($stdout)
+
+          assert_equal :stdout, appender.console_stream
+        end
+
+        it "is :stderr when writing to stderr" do
+          appender = SemanticLogger::Appender::IO.new($stderr)
+
+          assert_equal :stderr, appender.console_stream
+        end
+
+        it "is nil for other streams" do
+          io       = StringIO.new
+          appender = SemanticLogger::Appender::IO.new(io)
+
+          assert_nil appender.console_stream
+        end
+      end
     end
   end
 end

--- a/test/appenders_test.rb
+++ b/test/appenders_test.rb
@@ -101,7 +101,7 @@ class AppendersTest < Minitest::Test
         end
       end
 
-      it "prevents adding multiple console loggers" do
+      it "prevents adding a second appender to the same console stream" do
         appender = appenders.add(io: $stdout)
 
         assert_includes appenders, appender
@@ -110,11 +110,20 @@ class AppendersTest < Minitest::Test
 
         assert_nil appender
 
-        appender = appenders.add(io: $stderr)
-
-        assert_nil appender
-
         assert_equal 1, appenders.size
+      end
+
+      it "allows adding separate stdout and stderr console appenders" do
+        stdout_appender = appenders.add(io: $stdout)
+
+        assert_includes appenders, stdout_appender
+
+        stderr_appender = appenders.add(io: $stderr)
+
+        assert_includes appenders, stderr_appender
+
+        assert_equal 2, appenders.size
+        assert_equal %i[stdout stderr], appenders.console_streams
       end
 
       it "allows adding multiple loggers" do

--- a/test/subscriber_test.rb
+++ b/test/subscriber_test.rb
@@ -159,5 +159,11 @@ class SubscriberTest < Minitest::Test
         refute_predicate appender, :console_output?
       end
     end
+
+    describe "#console_stream" do
+      it "is nil by default" do
+        assert_nil appender.console_stream
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #203.

Semantic Logger previously rejected any second console appender, treating `$stdout` and `$stderr` as a single bucket. This blocked the common operational pattern of routing lower severity logs to stdout and warnings/errors to stderr (without the `/dev/stdout` file workaround, which breaks on systems lacking those device files).

This change tracks the two console streams **individually**. A second appender targeting a stream that is already in use is still ignored (to prevent duplicate console output), but stdout and stderr can now coexist.

```ruby
stdout_filter = ->(log) { %i[trace debug info].include?(log.level) }

SemanticLogger.add_appender(io: $stdout, formatter: :color, level: :trace, filter: stdout_filter)
SemanticLogger.add_appender(io: $stderr, formatter: :color, level: :warn)
```

## Changes

- `Subscriber#console_stream` returns `:stdout`, `:stderr`, or `nil`; `#console_output?` now derives from it (kept for compatibility).
- `Appender::IO` reports its stream via `#console_stream` (identity check on `@io`).
- `Appenders#add` only rejects when that specific stream is already in use; added `#console_streams` helper.
- `Appender::Async` delegates `console_stream`/`console_output?` so an async-wrapped console appender is still detected (the old code silently bypassed the check).
- Docs: new "Splitting output across stdout and stderr" section in `docs/appenders.md`.
- Tests updated/added in `appenders_test.rb`, `io_test.rb`, `subscriber_test.rb`.

## Compatibility

This is a behavior change targeted at the **v5** release: a previously-rejected second console appender now succeeds when it targets the *other* stream. The duplicate-output protection for the *same* stream is preserved.

## Testing

`bundle exec rake test` — 1226 tests, 0 failures (MongoDB tests skipped, no local DB). `bundle exec rubocop` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)