### PR TITLE
Add batch support to the HTTP appender (#278)

### DIFF
--- a/docs/appenders.md
+++ b/docs/appenders.md
@@ -695,6 +695,36 @@ SemanticLogger.add_appender(
 )
 ~~~
 
+#### Batching
+
+By default each log message is sent in its own HTTP request. To instead send
+multiple log messages in a single request as a JSON array, enable batching with
+`batch: true`. This is useful for endpoints that accept an array of objects and
+create one document per element, such as the
+[Filebeat http_endpoint input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-http_endpoint.html).
+
+~~~ruby
+SemanticLogger.add_appender(
+  appender: :http,
+  url:      "http://localhost:8088/path",
+  batch:    true
+)
+~~~
+
+When batching is enabled the appender runs in its own thread and flushes a batch
+once `batch_size` messages have accumulated (default: 300) or `batch_seconds`
+have elapsed (default: 5), whichever comes first:
+
+~~~ruby
+SemanticLogger.add_appender(
+  appender:      :http,
+  url:           "http://localhost:8088/path",
+  batch:         true,
+  batch_size:    100,
+  batch_seconds: 10
+)
+~~~
+
 ### TCP Appender (+SSL)
 
 The TCP appender supports sending JSON or other formatted messages to services that can accept log messages

--- a/lib/semantic_logger/appender.rb
+++ b/lib/semantic_logger/appender.rb
@@ -39,8 +39,9 @@ module SemanticLogger
                      &)
       appender = build(**args, &)
 
-      # If appender implements #batch, then it should use the batch proxy by default.
-      batch    = true if batch.nil? && appender.respond_to?(:batch)
+      # If appender implements #batch, then it should use the batch proxy by default,
+      # unless the appender opts out of batching by default (e.g. the HTTP appender).
+      batch    = true if batch.nil? && appender.respond_to?(:batch) && appender.batch_by_default?
 
       if batch == true
         Appender::AsyncBatch.new(

--- a/lib/semantic_logger/appender/http.rb
+++ b/lib/semantic_logger/appender/http.rb
@@ -16,6 +16,16 @@ require "openssl"
 #     appender: :http,
 #     url:      'http://localhost:8088/path'
 #   )
+#
+# Batching:
+# By default each log message is posted individually. To post multiple log
+# messages in a single request as a JSON array (for example to the Filebeat
+# http_endpoint input), enable batching when adding the appender:
+#   SemanticLogger.add_appender(
+#     appender: :http,
+#     url:      'http://localhost:8088/path',
+#     batch:    true
+#   )
 module SemanticLogger
   module Appender
     class Http < SemanticLogger::Subscriber
@@ -189,6 +199,21 @@ module SemanticLogger
         message = formatter.call(log, self)
         logger.trace(message)
         post(message)
+      end
+
+      # Forward a batch of log messages to the HTTP Server in a single request.
+      # Only used when the appender is created with `batch: true`.
+      def batch(logs)
+        message = formatter.batch(logs, self)
+        logger.trace(message)
+        post(message)
+      end
+
+      # The HTTP appender supports batching, but only when explicitly requested
+      # via `batch: true`, so that the default behaviour (one request per log
+      # message) is preserved.
+      def batch_by_default?
+        false
       end
 
       private

--- a/lib/semantic_logger/formatters/json.rb
+++ b/lib/semantic_logger/formatters/json.rb
@@ -11,6 +11,11 @@ module SemanticLogger
       def call(log, logger)
         super.to_json
       end
+
+      # Returns a batch of log messages as a single JSON array.
+      def batch(logs, logger)
+        "[#{logs.map { |log| call(log, logger) }.join(',')}]"
+      end
     end
   end
 end

--- a/lib/semantic_logger/subscriber.rb
+++ b/lib/semantic_logger/subscriber.rb
@@ -84,6 +84,13 @@ module SemanticLogger
       !console_stream.nil?
     end
 
+    # Whether an appender that implements #batch should be wrapped in a batch
+    # proxy automatically. Appenders that support batching but should only batch
+    # when explicitly requested (via `batch: true`) override this to return false.
+    def batch_by_default?
+      true
+    end
+
     private
 
     # Initializer for Abstract Class SemanticLogger::Subscriber

--- a/test/appender/http_test.rb
+++ b/test/appender/http_test.rb
@@ -71,6 +71,42 @@ module Appender
         end
       end
 
+      describe "batch" do
+        let(:log1) do
+          log         = SemanticLogger::Log.new("User", :info)
+          log.message = "message 1"
+          log
+        end
+
+        let(:log2) do
+          log         = SemanticLogger::Log.new("User", :warn)
+          log.message = "message 2"
+          log
+        end
+
+        it "is not batched by default" do
+          refute_predicate appender, :batch_by_default?
+        end
+
+        it "posts multiple log messages as a single JSON array" do
+          request = nil
+          appender.http.stub(:request, lambda { |r|
+            request = r
+            http_success
+          }) do
+            appender.batch([log1, log2])
+          end
+          array = JSON.parse(request.body)
+
+          assert_kind_of Array, array
+          assert_equal 2, array.size
+          assert_equal "message 1", array[0]["message"]
+          assert_equal "info", array[0]["level"]
+          assert_equal "message 2", array[1]["message"]
+          assert_equal "warn", array[1]["level"]
+        end
+      end
+
       it "supports http 204 success" do
         http_success = Net::HTTPSuccess.new("1.1", "204", "OK")
         request = nil


### PR DESCRIPTION
## Summary

Closes #278.

Adds opt-in batching to the HTTP appender so multiple log messages can be sent in a single request as a JSON array, for example to the [Filebeat `http_endpoint` input](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-http_endpoint.html), which "creates one document for each object in the array".

```ruby
SemanticLogger.add_appender(
  appender: :http,
  url:      "http://localhost:8088/path",
  batch:    true
)
```

## What changed

- **`Appender::Http#batch`** posts an array of log messages in one request, formatted by the formatter's `#batch`.
- **`Formatters::Json#batch`** renders an array of log entries as a single JSON array.
- **`Subscriber#batch_by_default?`** (new predicate, default `true`) lets an appender support batching while opting out of being auto-wrapped in the batch proxy. `Http` overrides it to `false`.
- **`Appender.factory`** now only auto-enables batching when the appender both implements `#batch` and returns `true` from `batch_by_default?`.

## Off by default

Batching had to stay off by default for the HTTP appender (per the issue). The factory previously auto-enabled batching for any appender implementing `#batch`, so simply adding `#batch` to `Http` would have silently turned every existing `:http` appender (and its `:splunk_http` / `:elasticsearch_http` subclasses) into async, JSON-array batches. The `batch_by_default?` gate avoids that breaking change while leaving the existing batch-by-default appenders (Elasticsearch, Loki, SignalFx) unchanged.

## Tests

- New batch tests in `test/appender/http_test.rb` (single request as JSON array, `batch_by_default?` is false).
- Full suite green (`1223 tests, 0 failures`; MongoDB tests skipped locally), rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)