### PR TITLE
Fix Fluentd formatter process_info exclusion (#190)

### DIFF
--- a/docs/appenders.md
+++ b/docs/appenders.md
@@ -191,6 +191,31 @@ Note:
   It does not contain any embedded newlines.
 * If a field has a nil value it is excluded from the output json.
 
+#### Fluentd log format
+
+The `:fluentd` formatter is the same as `:json`, except that it renames the log
+level fields to `severity` and `severity_index` so they are recognized by the
+Kubernetes Fluentd log collector.
+
+~~~ruby
+SemanticLogger.add_appender(io: $stdout, formatter: :fluentd)
+~~~
+
+Differences from the standard JSON format:
+
+* The `level` / `level_index` fields are named `severity` / `severity_index`.
+* `host` is excluded by default, since under Fluentd it is usually the (not very
+  useful) container id. Pass `log_host: true` to include it.
+* The process fields `pid`, `thread`, `file`, and `line` are excluded by default.
+  Pass `need_process_info: true` to include them.
+
+To override any of these defaults, construct the formatter explicitly:
+
+~~~ruby
+formatter = SemanticLogger::Formatters::Fluentd.new(log_host: true, need_process_info: true)
+SemanticLogger.add_appender(io: $stdout, formatter: formatter)
+~~~
+
 ### IO Streams
 
 Semantic Logger can log data to any IO Stream instance, such as $stderr or $stdout

--- a/lib/semantic_logger/formatters/fluentd.rb
+++ b/lib/semantic_logger/formatters/fluentd.rb
@@ -7,9 +7,9 @@ module SemanticLogger
     class Fluentd < Json
       attr_reader :need_process_info
 
-      def initialize(time_format: :rfc_3339, time_key: :time, need_process_info: false, **args)
+      def initialize(time_format: :rfc_3339, time_key: :time, need_process_info: false, log_host: false, **args)
         @need_process_info = need_process_info
-        super(time_format: time_format, time_key: time_key, **args)
+        super(time_format: time_format, time_key: time_key, log_host: log_host, **args)
       end
 
       def level
@@ -17,8 +17,19 @@ module SemanticLogger
         hash["severity_index"] = log.level_index
       end
 
-      def process_info
-        # Ignore fields: pid, thread, file and line by default
+      # Ignore process fields: pid, thread, file and line by default.
+      # These are rarely useful under Fluentd (e.g. containerized processes
+      # usually have pid 1), so they are only included when explicitly requested
+      # via `need_process_info: true`.
+      def pid
+        super if need_process_info
+      end
+
+      def thread_name
+        super if need_process_info
+      end
+
+      def file_name_and_line
         super if need_process_info
       end
     end

--- a/test/formatters/fluentd_test.rb
+++ b/test/formatters/fluentd_test.rb
@@ -72,6 +72,47 @@ module SemanticLogger
             assert_equal "RuntimeError", str["exception"]["name"]
           end
         end
+
+        describe "process info" do
+          let(:log) do
+            log             = SemanticLogger::Log.new("FluentdTest", level)
+            log.time        = log_time
+            log.thread_name = "worker-1"
+            log.backtrace   = backtrace
+            log
+          end
+
+          it "excludes pid, thread, file and line by default" do
+            hash = JSON.parse(formatter.call(log, nil))
+
+            refute hash.key?("pid"), "expected pid to be excluded"
+            refute hash.key?("thread"), "expected thread to be excluded"
+            refute hash.key?("file"), "expected file to be excluded"
+            refute hash.key?("line"), "expected line to be excluded"
+          end
+
+          it "excludes host by default" do
+            logger    = Struct.new(:host).new("my-host")
+            formatter = SemanticLogger::Formatters::Fluentd.new(log_application: false, log_environment: false)
+            hash      = JSON.parse(formatter.call(log, logger))
+
+            refute hash.key?("host"), "expected host to be excluded even when the logger has one"
+          end
+
+          it "includes pid, thread, file and line when need_process_info is true" do
+            formatter = SemanticLogger::Formatters::Fluentd.new(
+              log_host:          false,
+              log_application:   false,
+              need_process_info: true
+            )
+            hash = JSON.parse(formatter.call(log, nil))
+
+            assert_equal $$, hash["pid"]
+            assert_equal "worker-1", hash["thread"]
+            assert hash.key?("file"), "expected file to be included"
+            assert hash.key?("line"), "expected line to be included"
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #190.

## Problem

The `Fluentd` formatter's `process_info` override was dead code. The inheritance chain is `Fluentd < Json < Raw < Base`, and the rendering is driven by `Raw#call`, which calls separate `pid`, `thread_name`, and `file_name_and_line` methods, never `process_info`. On top of that, `super` inside the override would have raised `NoMethodError`, since none of `Json`/`Raw`/`Base` define `process_info` (it only exists in `Default`).

The net effect: the documented "ignore fields: pid, thread, file and line by default" behavior never worked, and those fields were always emitted.

## Changes

- Replace the dead `process_info` override with overrides of the methods `Raw#call` actually invokes (`pid`, `thread_name`, `file_name_and_line`). Each no-ops unless `need_process_info: true`.
- Default `log_host` to `false` for the Fluentd formatter. Under Fluentd the host is usually the not-very-useful container id (per the issue discussion). Pass `log_host: true` to include it.
- Add tests covering the default exclusions and the `need_process_info: true` / host opt-in.
- Document the `:fluentd` formatter in `docs/appenders.md`.

## Note on behavior change

Defaulting `log_host` to `false` changes output for existing Fluentd users who relied on the host field; this matches the intent discussed in #190. Worth a mention in release notes.

## Testing

- `bundle exec ruby -Itest test/formatters/fluentd_test.rb` → 6 tests, 12 assertions, 0 failures
- `bundle exec rubocop` on changed files → no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)