### PR TITLE
Enforce UTF-8 on JSON output (#180)

### DIFF
--- a/lib/semantic_logger/appender/new_relic_logs.rb
+++ b/lib/semantic_logger/appender/new_relic_logs.rb
@@ -58,8 +58,8 @@ module SemanticLogger
       def log(log)
         begin
           message = formatter.call(log, self) # Generate the structured log
-          json_message = message.to_json      # Convert the log to JSON
-          level = log.level.to_s.upcase       # Determine the log level
+          json_message = Utils.to_json(message) # Convert the log to JSON, repairing any non UTF-8 data
+          level = log.level.to_s.upcase # Determine the log level
           self.class.log_newrelic(json_message, level)
         rescue JSON::GeneratorError => e
           warn("Failed to serialize log message to JSON: #{e.message}")

--- a/lib/semantic_logger/appender/splunk_http.rb
+++ b/lib/semantic_logger/appender/splunk_http.rb
@@ -98,7 +98,7 @@ module SemanticLogger
         }
         message[:sourcetype]  = source_type if source_type
         message[:index]       = index if index
-        message.to_json
+        Utils.to_json(message)
       end
     end
   end

--- a/lib/semantic_logger/formatters/json.rb
+++ b/lib/semantic_logger/formatters/json.rb
@@ -9,7 +9,7 @@ module SemanticLogger
 
       # Returns log messages in JSON format
       def call(log, logger)
-        super.to_json
+        Utils.to_json(super)
       end
 
       # Returns a batch of log messages as a single JSON array.

--- a/lib/semantic_logger/formatters/logfmt.rb
+++ b/lib/semantic_logger/formatters/logfmt.rb
@@ -64,9 +64,9 @@ module SemanticLogger
         flattened = @parsed.map do |key, value|
           case value
           when Hash, Array
-            "#{key}=#{value.to_s.to_json}"
+            "#{key}=#{Utils.to_json(value.to_s)}"
           else
-            "#{key}=#{value.to_json}"
+            "#{key}=#{Utils.to_json(value)}"
           end
         end
 

--- a/lib/semantic_logger/formatters/loki.rb
+++ b/lib/semantic_logger/formatters/loki.rb
@@ -10,7 +10,7 @@ module SemanticLogger
         self.logger = logger
         self.log = log
 
-        {streams: [build_stream]}.to_json
+        Utils.to_json({streams: [build_stream]})
       end
 
       # Returns [String] a JSON batch of logs
@@ -22,7 +22,7 @@ module SemanticLogger
           build_stream
         end
 
-        {streams: streams}.to_json
+        Utils.to_json({streams: streams})
       end
 
       private
@@ -82,7 +82,7 @@ module SemanticLogger
 
         log.context.each do |key, value|
           serialized_value = if value.is_a?(Hash)
-                               value.to_json
+                               Utils.to_json(value)
                              else
                                value.to_s
                              end
@@ -144,7 +144,7 @@ module SemanticLogger
 
           result[string_key] = case value
                                when Hash
-                                 JSON.generate(stringify_hash(value))
+                                 Utils.to_json(stringify_hash(value))
                                else
                                  value.to_s
                                end

--- a/lib/semantic_logger/formatters/open_telemetry.rb
+++ b/lib/semantic_logger/formatters/open_telemetry.rb
@@ -5,6 +5,15 @@ module SemanticLogger
       # primitives allowed by OTLP logs in Ruby: String, Integer, Float, TrueClass, FalseClass
       PRIMS = [String, Integer, Float, TrueClass, FalseClass].freeze
 
+      # Returns the attributes hash submitted to the OpenTelemetry SDK.
+      #
+      # Unlike the JSON formatters there is no single `.to_json` boundary here:
+      # the hash is handed to the OTLP exporter, which requires valid UTF-8. Cleanse
+      # the whole structure so binary / non UTF-8 strings cannot break the export.
+      def call(log, logger)
+        Utils.encode_utf8(super)
+      end
+
       # Log level
       def level
         hash[:level]       = log.level.to_s
@@ -35,10 +44,11 @@ module SemanticLogger
 
           out[k.to_s] =
             if v.is_a?(Hash)
-              # Stringify whole hash.
-              v.transform_values { |vv| coerce_value(vv) }.
-                transform_keys!(&:to_s).
-                to_json
+              # Stringify whole hash. Cleanse here too: this runs while building the
+              # hash, before the top-level call cleanse, so it must not raise on its own.
+              Utils.to_json(
+                v.transform_values { |vv| coerce_value(vv) }.transform_keys!(&:to_s)
+              )
             else
               coerce_value(v)
             end

--- a/lib/semantic_logger/formatters/signalfx.rb
+++ b/lib/semantic_logger/formatters/signalfx.rb
@@ -101,7 +101,7 @@ module SemanticLogger
           data[:counter] = [hash]
         end
 
-        data.to_json
+        Utils.to_json(data)
       end
 
       # Returns [Hash] a batch of log messages.
@@ -138,7 +138,7 @@ module SemanticLogger
           end
         end
 
-        data.to_json
+        Utils.to_json(data)
       end
 
       private

--- a/lib/semantic_logger/formatters/syslog_cee.rb
+++ b/lib/semantic_logger/formatters/syslog_cee.rb
@@ -38,7 +38,7 @@ module SemanticLogger
 
       def call(log, logger)
         hash = super
-        create_syslog_packet("@cee: #{hash.to_json}")
+        create_syslog_packet("@cee: #{Utils.to_json(hash)}")
       end
 
       private

--- a/lib/semantic_logger/utils.rb
+++ b/lib/semantic_logger/utils.rb
@@ -1,3 +1,5 @@
+require "json"
+
 module SemanticLogger
   # Internal-use only utility functions for Semantic Logger.
   # Not intended for public use.
@@ -75,6 +77,72 @@ module SemanticLogger
     # Whether this path should be excluded from any cleansed backtrace
     def self.strip_path?(path)
       strip_paths.any? { |exclude| path.start_with?(exclude) }
+    end
+
+    # Serializes the value to JSON, repairing invalid UTF-8 only when necessary.
+    #
+    # Non UTF-8 data appears in well under 1% of log events, so it is wasteful to
+    # walk and reallocate the entire structure (see .encode_utf8) on every call.
+    # Instead this attempts `.to_json` directly and only falls back to cleansing
+    # when serialization fails because of an encoding problem.
+    #
+    # The exception raised for non UTF-8 data depends on the json gem version:
+    # older versions raise Encoding::UndefinedConversionError (an EncodingError),
+    # newer versions wrap it as JSON::GeneratorError, so both are rescued. The
+    # retry is attempted only once: if it still fails (for example a
+    # JSON::GeneratorError caused by something other than encoding, such as NaN),
+    # the error propagates unchanged rather than being swallowed.
+    def self.to_json(value)
+      value.to_json
+    rescue JSON::GeneratorError, EncodingError
+      encode_utf8(value).to_json
+    end
+
+    # Returns a copy of the supplied value with every String converted to valid UTF-8.
+    #
+    # Recurses through Hash and Array structures, cleansing both keys and values.
+    # Strings that are already valid UTF-8 are returned unchanged (the common case),
+    # so the fast path allocates nothing. Any other value (Symbol, Numeric, Time, nil,
+    # ...) is returned as-is.
+    #
+    # Used by .to_json on the rare failing path, and directly by formatters that
+    # serialize per value or emit to a non-JSON sink (where a single `.to_json`
+    # rescue boundary cannot catch an intermediate failure).
+    def self.encode_utf8(value)
+      case value
+      when String
+        encode_utf8_string(value)
+      when Hash
+        value.each_with_object({}) do |(key, val), hash|
+          hash[encode_utf8(key)] = encode_utf8(val)
+        end
+      when Array
+        value.map { |element| encode_utf8(element) }
+      else
+        value
+      end
+    end
+
+    # Options used when transcoding a string to UTF-8.
+    # Invalid byte sequences and characters that cannot be represented in UTF-8 are
+    # dropped rather than substituted, matching the preference in issue #180.
+    ENCODE_UTF8_OPTIONS = {invalid: :replace, undef: :replace, replace: "".freeze}.freeze
+
+    # Returns the string converted to valid UTF-8, dropping any invalid bytes.
+    def self.encode_utf8_string(string)
+      return string if string.encoding == Encoding::UTF_8 && string.valid_encoding?
+
+      if string.encoding == Encoding::UTF_8
+        # Correctly tagged as UTF-8 but contains invalid byte sequences.
+        string.scrub("")
+      else
+        # Different encoding (e.g. ASCII-8BIT / Latin-1): transcode into UTF-8.
+        string.encode(Encoding::UTF_8, **ENCODE_UTF8_OPTIONS)
+      end
+    rescue EncodingError
+      # Last resort for encodings without a converter to UTF-8: reinterpret the
+      # raw bytes as UTF-8 and drop anything invalid. Logging must never raise.
+      string.dup.force_encoding(Encoding::UTF_8).scrub("")
     end
   end
 end

--- a/test/formatters/json_test.rb
+++ b/test/formatters/json_test.rb
@@ -87,6 +87,107 @@ module SemanticLogger
           assert_equal "RuntimeError", parsed["exception"]["name"]
           assert_equal "Oh no",        parsed["exception"]["message"]
         end
+
+        # Issue #180: previously `.to_json` raised on non UTF-8 data (the exact class
+        # varies by json gem version) and the log entry was dropped. Every field that
+        # can carry caller-supplied strings must now serialize without raising.
+        describe "non-UTF-8 data (issue #180)" do
+          # A binary string holding a byte (0xE2) that is not valid UTF-8.
+          let(:bad) { "Bad: \xE2".b }
+
+          it "serializes host, application, and environment" do
+            appender = Struct.new(:host, :application, :environment).new("host\xE2".b, "app\xE2".b, "env\xE2".b)
+            parsed   = JSON.parse(formatter.call(log, appender))
+
+            assert_equal "host", parsed["host"]
+            assert_equal "app",  parsed["application"]
+            assert_equal "env",  parsed["environment"]
+          end
+
+          it "serializes the name" do
+            log.name = bad
+
+            assert_equal "Bad: ", parsed["name"]
+          end
+
+          it "serializes the thread name" do
+            log.thread_name = bad
+
+            assert_equal "Bad: ", parsed["thread"]
+          end
+
+          it "serializes the message" do
+            log.message = bad
+
+            assert_equal "Bad: ", parsed["message"]
+          end
+
+          it "serializes the metric name" do
+            log.metric        = bad
+            log.metric_amount = 3
+
+            assert_equal "Bad: ", parsed["metric"]
+            assert_equal 3, parsed["metric_amount"]
+          end
+
+          it "serializes tags" do
+            log.tags = ["good", bad]
+
+            assert_equal ["good", "Bad: "], parsed["tags"]
+          end
+
+          it "serializes named_tag keys and values" do
+            log.named_tags = {"key\xE2".b => bad}
+
+            assert_equal({"key" => "Bad: "}, parsed["named_tags"])
+          end
+
+          it "serializes a nested payload, including keys and arrays" do
+            log.payload = {"outer\xE2".b => {inner: bad, list: [bad]}}
+
+            assert_equal({"outer" => {"inner" => "Bad: ", "list" => ["Bad: "]}}, parsed["payload"])
+          end
+
+          it "serializes the exception message and backtrace" do
+            exception = RuntimeError.new(bad)
+            exception.set_backtrace(["good_file.rb:1", "bad_file\xE2.rb:2".b])
+            log.exception = exception
+
+            assert_equal "Bad: ", parsed["exception"]["message"]
+            assert_equal ["good_file.rb:1", "bad_file.rb:2"], parsed["exception"]["stack_trace"]
+          end
+
+          it "serializes a nested cause exception message" do
+            begin
+              begin
+                raise bad
+              rescue StandardError
+                raise "the effect"
+              end
+            rescue Exception => e
+              log.exception = e
+            end
+
+            assert_equal "Bad: ", parsed["exception"]["cause"]["message"]
+          end
+
+          it "serializes everything at once without raising" do
+            log.message    = bad
+            log.tags       = [bad]
+            log.named_tags = {"key\xE2".b => bad}
+            log.payload    = {"outer\xE2".b => {inner: bad}}
+
+            assert JSON.parse(formatter.call(log, appender))
+          end
+
+          it "does not mangle valid multibyte UTF-8 in the same document" do
+            log.message = "€ café"
+            log.payload = {"naïve" => "Bad: \xE2".b}
+
+            assert_equal "€ café", parsed["message"]
+            assert_equal({"naïve" => "Bad: "}, parsed["payload"])
+          end
+        end
       end
     end
   end

--- a/test/formatters/loki_test.rb
+++ b/test/formatters/loki_test.rb
@@ -301,6 +301,19 @@ module SemanticLogger
             assert_equal 100, payload_obj["metric_value"]
             assert_equal "RuntimeError", payload_obj["exception_name"]
           end
+
+          # Issue #180: .to_json raises Encoding::UndefinedConversionError on non UTF-8 data.
+          it "serializes non UTF-8 data without raising" do
+            log.message    = "Bad: \xE2".b
+            log.tags       = ["Tag: \xE2".b]
+            log.named_tags = {"name\xE2".b => "val\xE2".b}
+            log.payload    = {"key\xE2".b => "value\xE2".b}
+
+            assert_equal "Bad: ", values_data[1]
+            assert_equal ["Tag: "], stream_data["tags"]
+            assert_equal "val", stream_data["name"]
+            assert_equal "value", values_data[2]["key"]
+          end
         end
 
         describe "#batch" do

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -1,4 +1,5 @@
 require_relative "test_helper"
+require "json"
 
 module SemanticLogger
   class UtilsTest < Minitest::Test
@@ -100,6 +101,107 @@ module SemanticLogger
 
         it "is false for application paths" do
           refute SemanticLogger::Utils.strip_path?("/app/models/user.rb:10")
+        end
+      end
+
+      describe ".to_json" do
+        # A binary string holding a byte (0xE2) that is not valid UTF-8.
+        let(:binary_string) { "Bad: \xE2".b }
+
+        it "serializes valid data directly" do
+          assert_equal '{"a":1,"b":"x"}', SemanticLogger::Utils.to_json({a: 1, b: "x"})
+        end
+
+        it "repairs and serializes non UTF-8 data without raising" do
+          result = SemanticLogger::Utils.to_json(
+            {message: binary_string, list: [binary_string], "k\xE2".b => binary_string}
+          )
+
+          assert_equal({"message" => "Bad: ", "list" => ["Bad: "], "k" => "Bad: "}, JSON.parse(result))
+        end
+
+        it "only cleanses on failure, leaving valid strings identical" do
+          # The cleansing fallback drops invalid bytes; a direct serialization keeps
+          # everything. A multibyte UTF-8 string proves no lossy round-trip occurred.
+          assert_equal '"€ café"', SemanticLogger::Utils.to_json("€ café")
+        end
+
+        it "re-raises errors that cleansing cannot fix" do
+          # NaN is not representable in JSON and is unrelated to encoding, so the
+          # retry after cleansing must still raise rather than swallow it.
+          assert_raises(JSON::GeneratorError) do
+            SemanticLogger::Utils.to_json({value: Float::NAN})
+          end
+        end
+      end
+
+      describe ".encode_utf8" do
+        # A binary string holding a byte (0xE2) that is not valid UTF-8.
+        # This is the exact failure mode reported in issue #180.
+        let(:binary_string) { "Bad: \xE2".b }
+
+        # A string tagged as UTF-8 but containing an invalid byte sequence.
+        let(:invalid_utf8) { (+"Bad: \xE2").force_encoding(Encoding::UTF_8) }
+
+        it "returns a valid UTF-8 string unchanged" do
+          string = "Héllo"
+          result = SemanticLogger::Utils.encode_utf8(string)
+
+          assert_same string, result
+          assert_predicate result, :valid_encoding?
+        end
+
+        it "drops invalid bytes from a binary string" do
+          result = SemanticLogger::Utils.encode_utf8(binary_string)
+
+          assert_equal "Bad: ", result
+          assert_equal Encoding::UTF_8, result.encoding
+          assert_predicate result, :valid_encoding?
+        end
+
+        it "scrubs an invalid UTF-8 string" do
+          result = SemanticLogger::Utils.encode_utf8(invalid_utf8)
+
+          assert_equal "Bad: ", result
+          assert_equal Encoding::UTF_8, result.encoding
+          assert_predicate result, :valid_encoding?
+        end
+
+        it "transcodes a non UTF-8 encoding, preserving representable characters" do
+          result = SemanticLogger::Utils.encode_utf8("café".encode(Encoding::ISO_8859_1))
+
+          assert_equal "café", result
+          assert_equal Encoding::UTF_8, result.encoding
+        end
+
+        it "produces a string that can be serialized to JSON" do
+          result = SemanticLogger::Utils.encode_utf8(binary_string)
+
+          assert_equal '"Bad: "', result.to_json
+        end
+
+        it "recurses through nested hashes, cleansing keys and values" do
+          result = SemanticLogger::Utils.encode_utf8(
+            binary_string => {"inner\xE2".b => binary_string}
+          )
+
+          assert_equal({"Bad: " => {"inner" => "Bad: "}}, result)
+
+          all_strings = result.flat_map { |key, value| [key, *value.keys, *value.values] }
+
+          all_strings.each { |string| assert_predicate string, :valid_encoding? }
+        end
+
+        it "recurses through arrays" do
+          result = SemanticLogger::Utils.encode_utf8([binary_string, ["nested\xE2".b]])
+
+          assert_equal ["Bad: ", ["nested"]], result
+        end
+
+        it "leaves non-string scalars untouched" do
+          assert_equal 42, SemanticLogger::Utils.encode_utf8(42)
+          assert_equal :sym, SemanticLogger::Utils.encode_utf8(:sym)
+          assert_nil SemanticLogger::Utils.encode_utf8(nil)
         end
       end
     end


### PR DESCRIPTION
Fixes #180.

## Problem

When a logged string contained bytes that are not valid UTF-8 (for example binary / `ASCII-8BIT` data in a payload), `.to_json` raised inside the appender and the log entry was silently dropped:

```
Encoding::UndefinedConversionError: "\xE2" from ASCII-8BIT to UTF-8
```

The at-risk fields are everything that can carry caller-supplied strings: `message`, `tags`, `named_tags`, `payload`, `exception` (name / message / backtrace + nested causes), and `host` / `application` / `environment`.

## Approach

Add `Utils.to_json(value)`, which serializes directly and only falls back to a recursive UTF-8 cleanse (`Utils.encode_utf8`) plus a single retry **when serialization fails on an encoding error**. Non UTF-8 data shows up in well under 1% of log events, so the common path stays allocation-free instead of walking and reallocating the whole structure on every call.

Two details that shaped the implementation:

- **The exception class varies by json gem version.** Older versions raise `Encoding::UndefinedConversionError` (the issue's traceback); json 2.19 wraps it as `JSON::GeneratorError`. Both are rescued.
- **Retry-once is self-correcting.** An unrelated `GeneratorError` (e.g. `NaN`) still raises after cleansing, so non-encoding failures propagate unchanged rather than being swallowed.

`encode_utf8` cleanses recursively (keys and values), returns already-valid UTF-8 strings untouched, drops invalid/undefined bytes, and never raises.

## Where it is applied

- **Whole-document JSON (optimistic boundary):** `json`, `syslog_cee`, `splunk_http`, `new_relic_logs`, `signalfx`, `loki` (including Loki's two internal per-value serializations that run before the outer call).
- **Per-value / non-JSON sinks (explicit cleanse):** `logfmt` serializes each field separately; `open_telemetry` hands a hash to the OTLP exporter (which also requires valid UTF-8), so a single `to_json` rescue boundary cannot protect it.

`Raw#call` is reverted to a pure hash builder, so `Log#to_h` and the in-memory test appenders are unaffected.

## Tests

- `Utils.to_json` and `Utils.encode_utf8` unit tests (direct serialize, repair-on-failure, no mangling of valid multibyte UTF-8, NaN re-raises).
- A per-field matrix in `json_test.rb` asserted through real serialize + parse: every hash location that can carry non-UTF-8 data, plus an all-at-once case and a "does not mangle valid UTF-8 in the same document" case.
- Loki round-trip retained.

Full suite: 1256 tests, 0 failures. Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)