### PR TITLE
Automatically reopen appenders on fork by default (#338)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,9 +33,9 @@ bundle exec ruby -Itest test/logger_test.rb
 bundle exec ruby -Itest test/logger_test.rb -n /pattern/
 ```
 
-Some appender tests need MongoDB. CI runs against Ruby 2.7–3.4 with a MongoDB service on `127.0.0.1:27017` (`MONGO_HOST` env var). Use `docker compose up` (see `docker-compose.yaml` / `Dockerfile`) to run tests with a MongoDB container locally.
+Some appender tests need MongoDB. CI runs against Ruby 3.2–4.0 with a MongoDB service on `127.0.0.1:27017` (`MONGO_HOST` env var). Use `docker compose up` (see `docker-compose.yaml` / `Dockerfile`) to run tests with a MongoDB container locally.
 
-The minimum supported Ruby is 2.7, and rubocop's `TargetRubyVersion` is pinned to 2.7 — do not use syntax newer than that in `lib/`.
+The minimum supported Ruby is 3.2 (as of v5; see `gemspec` and `.rubocop.yml`'s `TargetRubyVersion`) — do not use syntax newer than that in `lib/`.
 
 ## Architecture
 
@@ -65,7 +65,7 @@ To add a new appender or formatter, add the class under the respective directory
 - **Levels** ([lib/semantic_logger/levels.rb](lib/semantic_logger/levels.rb)) — `:trace, :debug, :info, :warn, :error, :fatal`. Comparisons use a pre-computed integer `level_index` for speed; this is a recurring performance pattern, do not replace it with symbol comparisons.
 - **Tags & named tags** — thread-local context stored in `Thread.current[:semantic_logger_tags]` / `[:semantic_logger_named_tags]`. The fast paths (`SemanticLogger.tagged`, `.push_tags`, `.fast_tag`) assume clean string tags; the slower instance methods on `Base` flatten/reject-empty for Rails compatibility.
 - **`on_log` subscribers** ([lib/semantic_logger/logger.rb](lib/semantic_logger/logger.rb)) — callbacks run **inline on the calling thread** (before the queue hand-off) so they can capture request-scoped context. Keep them fast.
-- **Forking** — after `fork`, file handles and the queue must be re-created via `SemanticLogger.reopen` → `Appenders#reopen` → `Async#reopen`. `at_exit` in [lib/semantic_logger.rb](lib/semantic_logger.rb) flushes the queue on shutdown.
+- **Forking** — after `fork`, file handles and the queue must be re-created via `SemanticLogger.reopen` → `Appenders#reopen` → `Async#reopen`. As of v5 this happens automatically: a `Process._fork`/`daemon` hook ([lib/semantic_logger/core_ext/process.rb](lib/semantic_logger/core_ext/process.rb), prepended in [lib/semantic_logger.rb](lib/semantic_logger.rb)) calls `reopen` in the child unless `SemanticLogger.reopen_on_fork = false`. `reopen` is guarded to run once per process (pid-based; bypass with `reopen(force: true)`). `at_exit` in [lib/semantic_logger.rb](lib/semantic_logger.rb) flushes the queue on shutdown.
 - **`Loggable`** ([lib/semantic_logger/loggable.rb](lib/semantic_logger/loggable.rb)) — mixin giving a class both `self.logger` and instance `logger`, plus `logger_measure_method` which wraps a method (via a prepended module) to log its duration.
 
 ## Testing conventions

--- a/README.md
+++ b/README.md
@@ -97,6 +97,57 @@ and are therefore not automatically included by this gem:
 - Sentry Appender: gem 'sentry-ruby'
 - OpenTelemetry Appender: gem 'opentelemetry-logs-sdk' (plus an exporter, e.g. 'opentelemetry-exporter-otlp-logs')
 
+## Upgrading to Semantic Logger v5.0
+
+- Ruby 3.2 is now the minimum runtime version.
+
+### Appenders are now reopened automatically after a fork
+
+Previously, after a process forked (Puma, Unicorn, Resque, Spring, Phusion
+Passenger, parallel tests, etc.) you had to call `SemanticLogger.reopen` yourself
+in an `after_fork` style hook, otherwise logging would silently stop in the child.
+
+As of v5, Semantic Logger installs a `Process._fork` hook (Ruby 3.1+) that calls
+`SemanticLogger.reopen` automatically in the child process after `fork`,
+`Process.daemon`, `IO.popen`, `Kernel#system`, and backticks. No configuration is
+required for the common cases.
+
+**Recommended:** remove all of your existing manual reopen calls. For example,
+delete code such as:
+
+~~~ruby
+# config/unicorn.conf.rb
+after_fork do |server, worker|
+  SemanticLogger.reopen
+end
+
+# config/puma.rb
+before_worker_boot do
+  SemanticLogger.reopen
+end
+
+# Resque / Spring / Passenger
+Resque.after_fork  { SemanticLogger.reopen }
+Spring.after_fork  { SemanticLogger.reopen }
+PhusionPassenger.on_event(:starting_worker_process) { |forked| SemanticLogger.reopen if forked }
+~~~
+
+Leaving these in place is safe, since `SemanticLogger.reopen` now no-ops when it
+has already run in the current process after a fork, but they are no longer needed.
+
+**Opt out:** to restore the previous behavior and manage reopen yourself, disable
+the automatic hook during application boot:
+
+~~~ruby
+SemanticLogger.reopen_on_fork = false
+~~~
+
+If you need to reopen within the same process (for example after an external log
+rotation that did not fork), call `SemanticLogger.reopen(force: true)` to bypass
+the per-process guard.
+
+If you use Rails Semantic Logger, upgrade it alongside Semantic Logger v5.
+
 ## Upgrading to Semantic Logger v4.9
 
 These changes should not be noticeable by the majority of users of Semantic Logger, since

--- a/docs/forking.md
+++ b/docs/forking.md
@@ -7,78 +7,33 @@ layout: default
 In Ruby it is common for Frameworks such Puma and Resque to fork a copy of the
 process so that it can run independently from the parent process.
 
-After a process has forked `SemanticLogger.reopen` must be called to re-open
-files and re-start the appender thread. Otherwise, logging will appear to stop.
+After a process has forked, appenders must be re-opened to re-open files and
+re-start the appender thread. Otherwise, logging will appear to stop.
 
-Below are some of the common frameworks that use process forking and what you need
-to do so that Semantic Logger can continue to function after a fork:
+### Automatic reopen on fork (default)
 
-### Unicorn
+As of v5, Semantic Logger does this for you. It installs a `Process._fork` hook
+(Ruby 3.1 and later) that calls `SemanticLogger.reopen` in the child process after
+`fork`, `Process.daemon`, `IO.popen`, `Kernel#system`, and backticks. This covers
+all forking frameworks (Puma, Unicorn, Resque, Spring, Phusion Passenger, parallel
+tests, etc.) without any additional code.
 
-With Unicorn, add the following code to you Unicorn configuration:
+`SemanticLogger.reopen` no-ops if it has already run in the current process after a
+fork, so it is safe even if something else also calls it. If you need to reopen
+within the same process (for example after an external log rotation that did not
+fork), call `SemanticLogger.reopen(force: true)` to bypass that guard.
 
-~~~ruby
-# config/unicorn.conf.rb
-after_fork do |server, worker|
-  # Re-open appenders after forking the process
-  SemanticLogger.reopen
-end
-~~~
+### Opting out
 
-### Puma
-
-If running Puma in Clustered mode and you're preloading your application,
-add the following to your worker boot code:
+To restore full manual control, disable the automatic hook during application boot
+and call `SemanticLogger.reopen` yourself after each fork:
 
 ~~~ruby
-# config/puma.rb
-before_worker_boot do
-  # Re-open appenders after forking the process
-  SemanticLogger.reopen
-end
+SemanticLogger.reopen_on_fork = false
 ~~~
 
-### Rails with Minitest
-
-If you use [parallel tests in Rails with forking](https://guides.rubyonrails.org/testing.html#parallel-testing-with-processes), add the following to your `ActiveSupport::TestCase` class:
-
-~~~ruby
-# test/test_helper.rb
-parallelize_setup do |worker|
-  SemanticLogger.reopen
-end
-~~~
-
-### Auto-detected Frameworks
-
-The following frameworks are automatically detected by the `Rails Semantic Logger` gem,
-so the custom code below is only necessary when using Semantic Logger stand-alone:
-
-- Phusion Passenger
-- Resque
-- Spring
-
-Add the following code only if Rails Semantic Logger gem is not being used and
-you are using these frameworks:
-
-~~~ruby
-# Passenger provides the :starting_worker_process event for executing
-# code after it has forked, so we use that and reconnect immediately.
-if defined?(PhusionPassenger)
-  PhusionPassenger.on_event(:starting_worker_process) do |forked|
-    SemanticLogger.reopen if forked
-  end
-end
-
-# Re-open appenders after Resque has forked a worker
-if defined?(Resque)
-  Resque.after_fork { |job| ::SemanticLogger.reopen }
-end
-
-# Re-open appenders after Spring has forked a process
-if defined?(Spring)
-  Spring.after_fork { |job| ::SemanticLogger.reopen }
-end
-~~~
+You might opt out if, for example, another library also forks in ways you do not
+want to trigger a reopen, or you need to control exactly when the appender thread
+is restarted.
 
 ### [Next: Log Rotation ==>](log_rotation.html)

--- a/lib/semantic_logger.rb
+++ b/lib/semantic_logger.rb
@@ -18,6 +18,14 @@ require "semantic_logger/logger"
 require "semantic_logger/debug_as_trace_logger"
 require "semantic_logger/semantic_logger"
 
+# Automatically reopen appenders in the child process after a fork.
+# Enabled by default; opt out with `SemanticLogger.reopen_on_fork = false`.
+# Skipped on platforms without `Process._fork` (e.g. JRuby), which cannot fork.
+if Process.respond_to?(:_fork)
+  require "semantic_logger/core_ext/process"
+  Process.singleton_class.prepend(SemanticLogger::CoreExt::Process)
+end
+
 # Flush all appenders at exit, waiting for outstanding messages on the queue
 # to be written first.
 at_exit do

--- a/lib/semantic_logger/core_ext/process.rb
+++ b/lib/semantic_logger/core_ext/process.rb
@@ -1,0 +1,34 @@
+module SemanticLogger
+  module CoreExt
+    # Reopen all appenders in the child process after a fork.
+    #
+    # Prepended onto `Process.singleton_class` when Semantic Logger is loaded.
+    # Enabled by default; opt out with `SemanticLogger.reopen_on_fork = false`.
+    #
+    # `Process._fork` (Ruby 3.1+) is the single method that every fork path routes
+    # through (`Kernel#fork`, `Process.fork`, `IO.popen`, `Kernel#system`, and
+    # backticks), so overriding it covers them all with one hook.
+    #
+    # Note: both `_fork` and `daemon` must be overridden to reliably restart the
+    # appender thread, since `Process.daemon` does not route through `_fork`
+    # (https://bugs.ruby-lang.org/issues/18911). Do not collapse this down to only
+    # `_fork`.
+    module Process
+      # `_fork` runs in both the parent and the child. It returns 0 in the child
+      # and the child's pid in the parent, so only reopen in the child. Reopening
+      # in the parent would needlessly recreate its queue and worker thread,
+      # risking the loss of messages still on the queue.
+      def _fork
+        child_pid = super
+        SemanticLogger.reopen if child_pid.zero? && SemanticLogger.reopen_on_fork?
+        child_pid
+      end
+
+      # `Process.daemon` does not route through `_fork`, so reopen explicitly. Once
+      # it returns, the caller is running as the daemon (child) process.
+      def daemon(...)
+        super.tap { SemanticLogger.reopen if SemanticLogger.reopen_on_fork? }
+      end
+    end
+  end
+end

--- a/lib/semantic_logger/semantic_logger.rb
+++ b/lib/semantic_logger/semantic_logger.rb
@@ -202,14 +202,43 @@ module SemanticLogger
     Logger.processor.close
   end
 
-  # After forking an active process call SemanticLogger.reopen to re-open
-  # any open file handles etc to resources.
+  # Re-open any open file handles etc. to resources.
+  #
+  # Called automatically in the child process after a fork (see reopen_on_fork?),
+  # and may also be called manually.
+  #
+  # To avoid reopening twice after a single fork (for example when the automatic
+  # fork hook and a framework's `after_fork` callback both fire), reopen is a no-op
+  # if it has already run in the current process. Pass `force: true` to override
+  # this guard and reopen unconditionally, for example when re-opening file handles
+  # in the same process after an external log rotation.
   #
   # Note:
   #   Not all appender's implement reopen.
   #   Check the code for each appender you are using before relying on this behavior.
-  def self.reopen
+  def self.reopen(force: false)
+    return if !force && @reopened_pid == ::Process.pid
+
     Logger.processor.reopen
+    @reopened_pid = ::Process.pid
+  end
+
+  # Whether appenders are automatically reopened in the child process after a fork.
+  #
+  # Enabled by default. A `Process._fork` hook (Ruby 3.1+) calls SemanticLogger.reopen
+  # in the child after `fork`, `Process.daemon`, `IO.popen`, `Kernel#system`, and
+  # backticks, so framework specific `after_fork` hooks (Puma, Unicorn, Resque,
+  # Spring, etc.) are no longer required.
+  def self.reopen_on_fork?
+    @reopen_on_fork != false
+  end
+
+  # Enable or disable automatic reopening of appenders after a fork.
+  #
+  #   # Opt out of the automatic behavior and manage reopen manually:
+  #   SemanticLogger.reopen_on_fork = false
+  def self.reopen_on_fork=(reopen_on_fork)
+    @reopen_on_fork = reopen_on_fork
   end
 
   # Supply a callback to be called whenever a log entry is created.

--- a/lib/semantic_logger/version.rb
+++ b/lib/semantic_logger/version.rb
@@ -1,3 +1,3 @@
 module SemanticLogger
-  VERSION = "4.18.0".freeze
+  VERSION = "5.0.0".freeze
 end

--- a/test/core_ext/process_test.rb
+++ b/test/core_ext/process_test.rb
@@ -1,0 +1,148 @@
+require_relative "../test_helper"
+require "tempfile"
+
+require "semantic_logger/core_ext/process"
+
+module CoreExt
+  class ProcessTest < Minitest::Test
+    # Stand-in for `Process` that lets us drive `_fork`'s return value (the child
+    # pid in the parent, 0 in the child) without performing a real fork. The
+    # prepended module's `super` resolves to the `_fork` defined here.
+    class ForkStub
+      def initialize(fork_result)
+        @fork_result = fork_result
+      end
+
+      def _fork
+        @fork_result
+      end
+
+      def daemon(*)
+        :daemonized
+      end
+
+      prepend SemanticLogger::CoreExt::Process
+    end
+
+    # Records that it was reopened by touching a marker file. Used by the real
+    # fork test so the parent can observe what happened in the child.
+    class ReopenRecorder < SemanticLogger::Test::CaptureLogEvents
+      def initialize(marker)
+        super()
+        @marker = marker
+      end
+
+      def reopen
+        File.write(@marker, "reopened")
+      end
+    end
+
+    describe SemanticLogger::CoreExt::Process do
+      describe "#_fork" do
+        it "reopens in the child (super returns 0)" do
+          calls = 0
+
+          SemanticLogger.stub(:reopen, -> { calls += 1 }) do
+            assert_equal 0, ForkStub.new(0)._fork
+          end
+          assert_equal 1, calls
+        end
+
+        it "does not reopen in the parent (super returns the child pid)" do
+          calls = 0
+
+          SemanticLogger.stub(:reopen, -> { calls += 1 }) do
+            assert_equal 12_345, ForkStub.new(12_345)._fork
+          end
+          assert_equal 0, calls
+        end
+
+        it "does not reopen when reopen_on_fork is disabled" do
+          calls                         = 0
+          SemanticLogger.reopen_on_fork = false
+
+          SemanticLogger.stub(:reopen, -> { calls += 1 }) do
+            assert_equal 0, ForkStub.new(0)._fork
+          end
+          assert_equal 0, calls
+        ensure
+          SemanticLogger.reopen_on_fork = nil
+        end
+      end
+
+      describe "#daemon" do
+        it "reopens and returns the result of super" do
+          calls = 0
+
+          SemanticLogger.stub(:reopen, -> { calls += 1 }) do
+            assert_equal :daemonized, ForkStub.new(0).daemon
+          end
+          assert_equal 1, calls
+        end
+      end
+    end
+
+    describe "SemanticLogger.reopen_on_fork?" do
+      it "is enabled by default" do
+        assert_predicate SemanticLogger, :reopen_on_fork?
+      end
+
+      it "can be disabled" do
+        SemanticLogger.reopen_on_fork = false
+
+        refute_predicate SemanticLogger, :reopen_on_fork?
+      ensure
+        SemanticLogger.reopen_on_fork = nil
+      end
+    end
+
+    describe "SemanticLogger.reopen" do
+      it "reopens once per process and no-ops on a repeat call" do
+        calls = 0
+        SemanticLogger.instance_variable_set(:@reopened_pid, nil)
+
+        SemanticLogger::Logger.processor.stub(:reopen, -> { calls += 1 }) do
+          SemanticLogger.reopen
+          SemanticLogger.reopen
+        end
+
+        assert_equal 1, calls
+      end
+
+      it "reopens again when forced" do
+        calls = 0
+        SemanticLogger.instance_variable_set(:@reopened_pid, nil)
+
+        SemanticLogger::Logger.processor.stub(:reopen, -> { calls += 1 }) do
+          SemanticLogger.reopen
+          SemanticLogger.reopen(force: true)
+        end
+
+        assert_equal 2, calls
+      end
+    end
+
+    describe "automatic reopen after a real fork" do
+      it "reopens appenders in the child" do
+        skip "fork not supported on this platform" unless Process.respond_to?(:fork) && Process.respond_to?(:_fork)
+
+        marker = Tempfile.new("reopen_on_fork").path
+        File.delete(marker)
+
+        appender = SemanticLogger.add_appender(appender: ReopenRecorder.new(marker))
+        begin
+          pid = Process.fork do
+            # The _fork hook should have already reopened appenders in this child.
+            exit!(0)
+          end
+          Process.wait(pid)
+
+          assert_path_exists marker, "expected the appender to be reopened in the child"
+        ensure
+          SemanticLogger.remove_appender(appender)
+          FileUtils.rm_f(marker)
+        end
+      end
+    end
+  end
+end

--- a/test/semantic_logger_test.rb
+++ b/test/semantic_logger_test.rb
@@ -227,6 +227,9 @@ class SemanticLoggerTest < Minitest::Test
         mock.expect(:close, nil)
         mock.expect(:reopen, nil)
 
+        # Clear the per-process reopen guard so reopen is not skipped.
+        SemanticLogger.instance_variable_set(:@reopened_pid, nil)
+
         SemanticLogger::Logger.stub(:processor, mock) do
           SemanticLogger.flush
           SemanticLogger.close


### PR DESCRIPTION
## Summary

Resolves #338. Semantic Logger now reopens appenders automatically in the child process after a fork, removing the need for framework specific `after_fork` hooks.

A `Process._fork` hook (Ruby 3.1+) is installed at load time and calls `SemanticLogger.reopen` in the child after `fork`, `Process.daemon`, `IO.popen`, `Kernel#system`, and backticks. This covers Puma, Unicorn, Resque, Spring, Phusion Passenger, parallel tests, etc. with no user configuration.

This is a breaking change targeted at **v5**.

## Details

- **Child-only reopen.** `Process._fork` runs in both parent and child; it returns `0` in the child and the child pid in the parent, so reopen is gated on the child to leave the parent's queue and worker thread intact. `Process.daemon` is overridden separately since it does not route through `_fork` ([ruby-lang #18911](https://bugs.ruby-lang.org/issues/18911)).
- **Once-per-process guard.** `SemanticLogger.reopen` now no-ops if it has already run in the current process (pid based), so a leftover framework `after_fork` hook calling reopen a second time is harmless. Pass `reopen(force: true)` to bypass the guard (e.g. reopening file handles after an external log rotation).
- **Opt out** with `SemanticLogger.reopen_on_fork = false`.
- **Skipped** on platforms without `Process._fork` (e.g. JRuby), which cannot fork.

## Why default-on (opt-out) for v5

Forking without reopening silently stops logging in the child, which is a common and hard-to-debug footgun. Making it automatic is the safer default. The behavior change, the global `Process` prepend, and the formalized Ruby 3.2 minimum are all appropriate for a major version.

## Upgrade notes

- Ruby 3.2 is now the minimum runtime version.
- Existing manual `SemanticLogger.reopen` calls in `after_fork` hooks can (and should) be removed. Leaving them in place is safe due to the per-process guard.
- See the new "Upgrading to Semantic Logger v5.0" section in the README.
- Rails Semantic Logger v5 will be updated to drop its framework auto-detection hooks in favor of this.

## Changes

- `lib/semantic_logger/core_ext/process.rb` — new `_fork`/`daemon` hook
- `lib/semantic_logger.rb` — prepend the hook at load (guarded by `Process.respond_to?(:_fork)`)
- `lib/semantic_logger/semantic_logger.rb` — `reopen(force:)` guard, `reopen_on_fork?` / `reopen_on_fork=`
- `lib/semantic_logger/version.rb` — bump to 5.0.0
- `README.md`, `docs/forking.md`, `CLAUDE.md` — docs

## Testing

- New `test/core_ext/process_test.rb`: child/parent branching, disabled flag, `daemon`, default-on predicate, once-per-process guard + `force`, and a real-fork integration test. Verified order-independent across random seeds.
- Full suite passes in both default and `LOGGER_SYNC=1` modes (1265 tests, 0 failures; MongoDB tests skipped without `MONGO_HOST`).
- Rubocop clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)