### PR TITLE
Add per-logger (child logger) tags

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,8 @@ Metrics/ClassLength:
   Max: 250
   Exclude:
     - "test/**/*"
+    # Large abstract base class shared by Logger and Subscriber.
+    - "lib/semantic_logger/base.rb"
 
 # Soften limits
 Metrics/MethodLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- Add per-logger (child logger) tags: calling `logger.tagged(...)` (or `with_tags`) without a
+  block now returns a new logger instance that permanently carries the supplied positional and/or
+  named tags, scoped to that logger only. Resolves #165. Combines the approaches from #301 (theocodes)
+  and #321 (Fire-Dragon-DoL).
 - Add upgrading guide to docs site covering v4.0 through v4.18, replace README upgrade sections with a link to the new page.
 
 ## [4.18.0]

--- a/docs/api.md
+++ b/docs/api.md
@@ -407,6 +407,53 @@ SemanticLogger.tagged(user: "Jack", zip_code: 12345) do
 end
 ~~~
 
+### Per-logger tags (child loggers)
+
+The block form of `tagged` above scopes its tags to the current thread, so they apply
+to every logger used inside the block. Sometimes it is more convenient to bind tags to
+a single logger instance instead, for example when a logger is owned by an object that
+has its own identity (such as an ActiveRecord model or a background job).
+
+Calling `tagged` (or its alias `with_tags`) **without a block** returns a new "child"
+logger that permanently carries the supplied tags. Every log entry emitted by that
+child, and only that child, includes the tags, even across threads:
+
+~~~ruby
+class Cart
+  include SemanticLogger::Loggable
+
+  def initialize(id)
+    @id     = id
+    # Bind this Cart's identity to its own logger instance.
+    @logger = SemanticLogger["Cart"].tagged(cart_id: id)
+  end
+
+  attr_reader :logger
+
+  def add_item(item_id)
+    # Automatically tagged with cart_id, without wrapping every method in a block.
+    logger.info("Added item", item_id: item_id)
+  end
+end
+~~~
+
+Both positional and named tags are supported, and may be mixed:
+
+~~~ruby
+logger = SemanticLogger["Payments"].tagged("billing", region: "eu")
+logger.info("Charged card") # tagged with ["billing"] and {region: "eu"}
+~~~
+
+Notes:
+
+- The original logger is never modified; `tagged` returns a copy. Child loggers can be
+  nested, with each level adding to the tags inherited from its parent.
+- Instance tags are combined with any thread tags from a surrounding `tagged` block:
+  positional tags from the thread come first, then the logger's instance tags. For named
+  tags, the logger's own tags win on a key conflict since they represent its identity.
+- Child loggers are ordinary logger instances; they are not registered anywhere, so they
+  are garbage collected along with the object that owns them.
+
 ### Named threads
 
 Semantic Logger logs the name or id of the thread in every log message.

--- a/lib/semantic_logger/base.rb
+++ b/lib/semantic_logger/base.rb
@@ -198,7 +198,18 @@ module SemanticLogger
     #   to:
     #     `logger.tagged('first', 'more', 'other')`
     # - For better performance with clean tags, see `SemanticLogger.tagged`.
+    #
+    # Child logger:
+    # - When called *without* a block, returns a new logger instance that permanently
+    #   carries the supplied tags ("instance tags"). Those tags are added to every log
+    #   entry emitted by the returned logger, and _only_ that logger, even across threads.
+    #   Unlike the block form they are not pushed onto the thread, so other loggers are
+    #   unaffected. This is the recommended way to bind a logger to an object's identity:
+    #     logger = SemanticLogger['Cart'].tagged(cart_id: cart.id)
     def tagged(*tags)
+      # No block: build a child logger that carries these tags on every entry.
+      return tagged_child(tags) unless block_given?
+
       block = -> { yield(self) }
       # Allow named tags to be passed into the logger
       # Rails::Rack::Logger passes logs as an array with a single argument
@@ -225,6 +236,10 @@ module SemanticLogger
     def named_tags
       SemanticLogger.named_tags
     end
+
+    # Tags permanently bound to this logger instance via `#tagged` (without a block).
+    # Empty for a regular (non-child) logger.
+    attr_reader :instance_tags, :instance_named_tags
 
     # Returns the list of tags pushed after flattening them out and removing blanks
     #
@@ -263,6 +278,11 @@ module SemanticLogger
       meets_log_level?(log) && !filtered?(log)
     end
 
+    protected
+
+    # Only assigned to when building a child logger via `#tagged` (see #tagged_child).
+    attr_writer :instance_tags, :instance_named_tags
+
     private
 
     # Initializer for Abstract Class SemanticLogger::Base
@@ -294,8 +314,13 @@ module SemanticLogger
         raise ":filter must be a Regexp, Proc, or implement :call"
       end
 
-      @filter = filter.is_a?(Regexp) ? filter.freeze : filter
-      @name   = klass.is_a?(String) ? klass : klass.name
+      @filter              = filter.is_a?(Regexp) ? filter.freeze : filter
+      @name                = klass.is_a?(String) ? klass : klass.name
+      # `[].freeze` / `{}.freeze` compile to `opt_ary_freeze` / `opt_hash_freeze`, which return
+      # a shared frozen singleton. Every logger points at the same two objects, so these default
+      # (empty) instance tags allocate no garbage. Child loggers replace them via #tagged_child.
+      @instance_tags       = [].freeze
+      @instance_named_tags = {}.freeze
       if level.nil?
         # Allow the global default level to determine this loggers log level
         @level_index = nil
@@ -324,6 +349,52 @@ module SemanticLogger
       (level_index <= (log.level_index || 0))
     end
 
+    # Build a new Log entry, layering this logger's instance tags on top of the
+    # current thread context.
+    def new_log(level, index = nil)
+      apply_instance_tags(Log.new(name, level, index))
+    end
+
+    # Merge this logger's instance tags into the supplied Log entry.
+    #
+    # Composition (mirrors the per-logger merge rule proposed in PR #301):
+    # - Positional: thread tags first, then this logger's instance tags appended.
+    # - Named: instance named tags merged on top of the thread named tags, so on a
+    #   key conflict the logger's own identity wins (it is the more specific value).
+    # Only this logger's entries are affected; the thread context is left untouched.
+    def apply_instance_tags(log)
+      unless @instance_tags.empty?
+        log.tags = log.tags.empty? ? @instance_tags.dup : log.tags + @instance_tags
+      end
+      unless @instance_named_tags.empty?
+        log.named_tags = log.named_tags.empty? ? @instance_named_tags.dup : log.named_tags.merge(@instance_named_tags)
+      end
+      log
+    end
+
+    # Returns a copy of this logger that permanently carries the supplied tags.
+    # Positional (string) and named (Hash) tags may be mixed; they are merged on
+    # top of any instance tags this logger already carries.
+    def tagged_child(tags)
+      positional = @instance_tags.dup
+      named      = @instance_named_tags.dup
+      tags.flatten.each do |tag|
+        case tag
+        when Hash
+          named = named.merge(tag)
+        when nil, ""
+          # Ignore blanks for Rails compatibility, matching the block form.
+        else
+          positional << tag.to_s
+        end
+      end
+
+      child                     = clone
+      child.instance_tags       = positional.freeze
+      child.instance_named_tags = named.freeze
+      child
+    end
+
     # Log message at the specified level
     def log_internal(level, index, message = nil, payload = nil, exception = nil)
       # Handle variable number of arguments by detecting exception object and payload hash.
@@ -338,7 +409,7 @@ module SemanticLogger
         payload = nil
       end
 
-      log = Log.new(name, level, index)
+      log = new_log(level, index)
       should_log =
         if exception.nil? && payload.nil? && message.is_a?(Hash)
           # All arguments as a hash in the message.
@@ -389,7 +460,7 @@ module SemanticLogger
         exception = e
       ensure
         # Must use ensure block otherwise a `return` in the yield above will skip the log entry
-        log = Log.new(name, level, index)
+        log = new_log(level, index)
         exception ||= params[:exception]
         message   = params[:message] if params[:message]
         duration  =
@@ -437,7 +508,7 @@ module SemanticLogger
       rescue Exception => e
         exception = e
       ensure
-        log = Log.new(name, level, index)
+        log = new_log(level, index)
         # May return false due to elastic logging
         should_log = log.assign(
           message:            message,

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -183,5 +183,110 @@ class LoggerTest < Minitest::Test
         end
       end
     end
+
+    describe "#tagged without a block (child logger)" do
+      it "returns a new logger instance, not self" do
+        child = logger.tagged(cart_id: 5)
+
+        refute_same logger, child
+        assert_kind_of logger.class, child
+      end
+
+      it "adds named instance tags to every entry from the child" do
+        child = logger.tagged(cart_id: 5)
+        child.info("hello")
+
+        assert log = child.events.last
+        assert_equal({cart_id: 5}, log.named_tags)
+      end
+
+      it "adds positional instance tags to every entry from the child" do
+        child = logger.tagged("service-a")
+        child.info("hello")
+
+        assert log = child.events.last
+        assert_equal ["service-a"], log.tags
+      end
+
+      it "supports mixing positional and named tags" do
+        child = logger.tagged("service-a", cart_id: 5)
+        child.info("hello")
+
+        assert log = child.events.last
+        assert_equal ["service-a"], log.tags
+        assert_equal({cart_id: 5}, log.named_tags)
+      end
+
+      it "does not add instance tags to the parent logger" do
+        logger.tagged(cart_id: 5)
+        logger.info("hello")
+
+        assert log = logger.events.last
+        assert_empty log.named_tags
+        assert_empty logger.instance_named_tags
+      end
+
+      it "does not add instance tags to other loggers within a thread block" do
+        another = SemanticLogger::Test::CaptureLogEvents.new
+        child   = logger.tagged(cart_id: 5)
+
+        SemanticLogger.tagged("request-1") do
+          child.info("from child")
+          another.info("from another")
+        end
+
+        assert_equal ["request-1"], child.events.last.tags
+        assert_equal({cart_id: 5}, child.events.last.named_tags)
+        assert_equal ["request-1"], another.events.last.tags
+        assert_empty another.events.last.named_tags
+      end
+
+      it "layers thread context with instance tags, instance named tags winning on conflict" do
+        child = logger.tagged("instance-pos", scope: "instance")
+
+        SemanticLogger.named_tagged(scope: "thread", request_id: "123") do
+          SemanticLogger.tagged("thread-pos") do
+            child.info("hello")
+          end
+        end
+
+        assert log = child.events.last
+        assert_equal %w[thread-pos instance-pos], log.tags
+        assert_equal({scope: "instance", request_id: "123"}, log.named_tags)
+      end
+
+      it "merges tags cumulatively for nested child loggers" do
+        child      = logger.tagged("a", one: 1)
+        grandchild = child.tagged("b", two: 2)
+        grandchild.info("hello")
+
+        assert log = grandchild.events.last
+        assert_equal %w[a b], log.tags
+        assert_equal({one: 1, two: 2}, log.named_tags)
+      end
+
+      it "leaves the parent unchanged when building a grandchild" do
+        child = logger.tagged("a", one: 1)
+        child.tagged("b", two: 2)
+
+        assert_equal ["a"], child.instance_tags
+        assert_equal({one: 1}, child.instance_named_tags)
+      end
+
+      it "applies instance tags to measure entries" do
+        child = logger.tagged(cart_id: 5)
+        child.measure_info("timed") { :result }
+
+        assert log = child.events.last
+        assert_equal({cart_id: 5}, log.named_tags)
+      end
+
+      it "ignores blank positional tags for rails compatibility" do
+        child = logger.tagged("", nil, "real")
+        child.info("hello")
+
+        assert_equal ["real"], child.events.last.tags
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Adds **per-logger tags** (child loggers): calling `logger.tagged(...)` (or its alias `with_tags`) **without a block** now returns a new logger instance that permanently carries the supplied positional and/or named tags. Every log entry from that logger, and only that logger, includes the tags, even across threads, without pushing onto the thread-local tag stack.

This lets a logger be bound to an object's identity without wrapping every call site in a `tagged { }` block:

```ruby
class Cart
  include SemanticLogger::Loggable

  def initialize(id)
    @logger = SemanticLogger["Cart"].tagged(cart_id: id)
  end
  attr_reader :logger

  def add_item(item_id)
    logger.info("Added item", item_id: item_id) # auto-tagged with cart_id
  end
end
```

Resolves #165.

## Credit

This combines the two approaches from the long-running discussion on #165:

- **#301 by @theocodes** — the per-logger named-tag composition rule (instance tags layered onto the thread context, instance winning on key conflicts).
- **#321 by @Fire-Dragon-DoL** — the child-logger ergonomics (`tagged` without a block returns a logger carrying instance tags, à la Rails `ActiveSupport::TaggedLogging`).

Both are credited as co-authors on the commit.

## Behavior

- **With a block**: unchanged. `tagged` still pushes thread-local tags exactly as before. The no-block form previously raised `LocalJumpError`, so this is purely additive and backward compatible.
- **Scoped to that logger**: instance tags never leak onto other loggers, even inside a surrounding `SemanticLogger.tagged { }` block.
- **Composition**: thread positional tags first, then the logger's instance tags; named tags merge with the logger's own tags winning on conflict (its identity is the more specific value).
- **No leak risk**: child loggers are plain copies, registered nowhere, so they are garbage collected with the object that owns them.
- **Coverage**: instance tags are applied across the normal log path and the `measure_*` / `measure_method` paths.

## Implementation notes

Intentionally minimal: no formatter changes and no new `Log` fields. Instance tags are merged into the existing `log.tags` / `log.named_tags` at build time via a small `new_log` helper wired into the three logging paths in `base.rb`.

The `.rubocop.yml` change makes the pre-existing (but inert) `ClassLength` exclusion for `base.rb` actually take effect; the main config's `Exclude` had been overriding the entry already present in `.rubocop_todo.yml`.

## Tests

- 11 new tests in `test/logger_test.rb` covering scoping, composition, nesting, parent immutability, the `measure_*` path, and blank-tag handling.
- Full suite green (`1276 tests, 0 failures`, MongoDB tests skipped without `MONGO_HOST`).
- `rubocop` clean on the changed files.

## Docs

New "Per-logger tags (child loggers)" section in `docs/api.md`, and a `CHANGELOG` entry crediting both PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)