### PR TITLE
Add SemanticLogger.stats for operational metrics (#164)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -675,6 +675,38 @@ Inspect the queue at runtime:
 SemanticLogger.queue_size
 ~~~
 
+For a fuller operational picture, including per-appender queues, use `SemanticLogger.stats`. It
+returns a Hash describing the main pipeline and every appender, which is handy for exporting
+Semantic Logger's own health to a monitoring system such as Prometheus or statsd:
+
+~~~ruby
+SemanticLogger.stats
+# => {
+#      queue_size:     0,       # entries waiting on the main pipeline queue
+#      capped:         true,    # whether the main queue has a maximum size
+#      max_queue_size: 10_000,  # nil when uncapped
+#      thread_active:  true,    # whether the main pipeline thread is running
+#      processed:      1_532,   # cumulative entries processed since startup
+#      dropped:        0,       # cumulative entries dropped at the main queue
+#      appenders: [
+#        { name: "SemanticLogger::Appender::File", async: false },
+#        { name:           "SemanticLogger::Appender::Http",
+#          async:          true,    # this appender has its own thread and queue
+#          thread_active:  true,
+#          queue_size:     3,
+#          capped:         true,
+#          max_queue_size: 10_000,
+#          processed:      1_529,
+#          dropped:        0 }
+#      ]
+#    }
+~~~
+
+The `processed` and `dropped` counters are cumulative since process startup. Reading `stats` is
+thread-safe and adds no locking to the logging hot path. Appenders that log inline on the pipeline
+thread report only their `name` with `async: false`; appenders given their own thread (see below)
+also report their own queue size and counters.
+
 Semantic Logger also logs a warning when an entry has been waiting on the queue for too long. The
 threshold, and how often it is checked, can be inspected and tuned:
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -20,6 +20,11 @@ when the level is `:info`.
 
 There are two kinds of metric: **duration** metrics and **counting** metrics.
 
+> **Not to be confused with operational stats.** The metrics on this page are *application*
+> metrics that your code emits about what it is doing. To monitor Semantic Logger's *own* health
+> instead, such as queue sizes and the number of log entries processed or dropped, use
+> [`SemanticLogger.stats`](api.html#monitoring-the-background-log-thread).
+
 ### Duration Metrics
 
 Log how long it took to call an external interface and send that duration as a metric to all

--- a/lib/semantic_logger/appender/async.rb
+++ b/lib/semantic_logger/appender/async.rb
@@ -66,6 +66,8 @@ module SemanticLogger
         @dropped_message_count          = 0
         @dropped_message_reported_at    = Time.now
         @dropped_message_mutex          = Mutex.new
+        @processed_count                = 0
+        @dropped_count                  = 0
         create_queue
         thread
       end
@@ -106,6 +108,30 @@ module SemanticLogger
       # Returns true if the worker thread is active
       def active?
         @thread&.alive?
+      end
+
+      # Returns [Hash] operational statistics for this appender.
+      #
+      #   name:           [String]  Name of the wrapped appender.
+      #   async:          [true]    This appender logs asynchronously via a separate thread.
+      #   thread_active:  [Boolean] Whether the worker thread is currently running.
+      #   queue_size:     [Integer] Number of log messages currently waiting to be written.
+      #   capped:         [Boolean] Whether the queue has a maximum size.
+      #   max_queue_size: [Integer] Maximum queue size, or nil when uncapped.
+      #   processed:      [Integer] Cumulative number of log messages written since startup.
+      #   dropped:        [Integer] Cumulative number of log messages dropped because the queue
+      #                             was full (only possible when non_blocking is enabled).
+      def stats
+        {
+          name:           name,
+          async:          true,
+          thread_active:  active? || false,
+          queue_size:     queue.size,
+          capped:         capped?,
+          max_queue_size: capped? ? max_queue_size : nil,
+          processed:      @processed_count,
+          dropped:        @dropped_count
+        }
       end
 
       # Add log message for processing.
@@ -187,6 +213,7 @@ module SemanticLogger
         while (message = queue.pop)
           if message.is_a?(Log)
             appender.log(message)
+            @processed_count += 1
             count += 1
             # Check every few log messages whether this appender thread is falling behind
             if count > lag_check_interval
@@ -221,6 +248,7 @@ module SemanticLogger
       def message_dropped
         @dropped_message_mutex.synchronize do
           @dropped_message_count += 1
+          @dropped_count         += 1
           diff = Time.now - @dropped_message_reported_at
           return if diff < dropped_message_report_seconds
 

--- a/lib/semantic_logger/appender/async_batch.rb
+++ b/lib/semantic_logger/appender/async_batch.rb
@@ -81,7 +81,10 @@ module SemanticLogger
               messages << message
             end
           end
-          appender.batch(logs) if logs.size.positive?
+          if logs.size.positive?
+            appender.batch(logs)
+            @processed_count += logs.size
+          end
           messages.each { |message| process_message(message) }
           signal.reset unless queue.size >= batch_size
         end

--- a/lib/semantic_logger/appenders.rb
+++ b/lib/semantic_logger/appenders.rb
@@ -33,6 +33,21 @@ module SemanticLogger
       console_streams.any?
     end
 
+    # Returns [Array<Hash>] operational statistics for each appender.
+    #
+    # Appenders that run asynchronously (see SemanticLogger::Appender::Async#stats) report
+    # their queue size and processed/dropped counts. Appenders that log inline on the
+    # processor thread report only their name with `async: false`.
+    def stats
+      map do |appender|
+        if appender.respond_to?(:stats)
+          appender.stats
+        else
+          {name: appender.name, async: false}
+        end
+      end
+    end
+
     def log(log)
       each do |appender|
         appender.log(log) if appender.should_log?(log)

--- a/lib/semantic_logger/processor.rb
+++ b/lib/semantic_logger/processor.rb
@@ -35,5 +35,26 @@ module SemanticLogger
       thread
       true
     end
+
+    # Returns [Hash] operational statistics for the logging pipeline.
+    #
+    #   queue_size:     [Integer] Number of log messages waiting on the main pipeline queue.
+    #   capped:         [Boolean] Whether the main queue has a maximum size.
+    #   max_queue_size: [Integer] Maximum queue size, or nil when uncapped.
+    #   thread_active:  [Boolean] Whether the main pipeline thread is running.
+    #   processed:      [Integer] Cumulative number of log messages processed since startup.
+    #   dropped:        [Integer] Cumulative number of log messages dropped at the main queue.
+    #   appenders:      [Array<Hash>] Per-appender statistics, see Appenders#stats.
+    def stats
+      {
+        queue_size:     queue.size,
+        capped:         capped?,
+        max_queue_size: capped? ? max_queue_size : nil,
+        thread_active:  active? || false,
+        processed:      @processed_count,
+        dropped:        @dropped_count,
+        appenders:      appenders.stats
+      }
+    end
   end
 end

--- a/lib/semantic_logger/semantic_logger.rb
+++ b/lib/semantic_logger/semantic_logger.rb
@@ -504,6 +504,27 @@ module SemanticLogger
     Logger.processor.queue.size
   end
 
+  # Returns [Hash] operational statistics for the logging pipeline.
+  #
+  # Useful for exporting Semantic Logger's own health to a monitoring system such as
+  # Prometheus, statsd, etc. The returned Hash contains:
+  #
+  #   queue_size:     [Integer] Number of log messages waiting on the main pipeline queue.
+  #   capped:         [Boolean] Whether the main queue has a maximum size.
+  #   max_queue_size: [Integer] Maximum queue size, or nil when uncapped.
+  #   thread_active:  [Boolean] Whether the main pipeline thread is running.
+  #   processed:      [Integer] Cumulative number of log messages processed since startup.
+  #   dropped:        [Integer] Cumulative number of log messages dropped at the main queue.
+  #   appenders:      [Array<Hash>] Per-appender statistics. Appenders that run their own
+  #                                 async thread report their queue_size and processed/dropped
+  #                                 counts; appenders that log inline report `async: false`.
+  #
+  # All counters are cumulative since process startup. They are thread-safe to read and
+  # are maintained without adding any locking to the logging hot path.
+  def self.stats
+    Logger.processor.stats
+  end
+
   # Returns the check_interval which is the number of messages between checks
   # to determine if the appender thread is falling behind.
   def self.lag_check_interval

--- a/lib/semantic_logger/sync_processor.rb
+++ b/lib/semantic_logger/sync_processor.rb
@@ -9,7 +9,28 @@ module SemanticLogger
     end
 
     def log(...)
-      @monitor.synchronize { @appenders.log(...) }
+      @monitor.synchronize do
+        @processed_count += 1
+        @appenders.log(...)
+      end
+    end
+
+    # Returns [Hash] operational statistics for the logging pipeline.
+    #
+    # In synchronous mode there is no queue: messages are written inline on the calling
+    # thread, so queue_size is always 0 and no messages can be dropped.
+    def stats
+      @monitor.synchronize do
+        {
+          queue_size:     0,
+          capped:         false,
+          max_queue_size: nil,
+          thread_active:  false,
+          processed:      @processed_count,
+          dropped:        0,
+          appenders:      @appenders.stats
+        }
+      end
     end
 
     def flush
@@ -47,8 +68,9 @@ module SemanticLogger
     attr_reader :appenders
 
     def initialize(appenders = nil)
-      @monitor   = Monitor.new
-      @appenders = appenders || Appenders.new(self.class.logger.dup)
+      @monitor         = Monitor.new
+      @appenders       = appenders || Appenders.new(self.class.logger.dup)
+      @processed_count = 0
     end
 
     def start

--- a/test/appender/async_test.rb
+++ b/test/appender/async_test.rb
@@ -40,6 +40,54 @@ module Appender
         end
       end
 
+      describe "stats" do
+        it "reports operational statistics" do
+          proxy = SemanticLogger::Appender::Async.new(appender: appender, max_queue_size: 100)
+          stats = proxy.stats
+
+          assert_equal appender.name, stats[:name]
+          assert stats[:async]
+          assert stats[:capped]
+          assert_equal 100, stats[:max_queue_size]
+          assert_equal 0, stats[:dropped]
+          assert_kind_of Integer, stats[:queue_size]
+          assert_kind_of Integer, stats[:processed]
+        ensure
+          proxy&.close
+        end
+
+        it "reports nil max_queue_size for an uncapped queue" do
+          proxy = SemanticLogger::Appender::Async.new(appender: appender, max_queue_size: -1)
+          stats = proxy.stats
+
+          refute stats[:capped]
+          assert_nil stats[:max_queue_size]
+        ensure
+          proxy&.close
+        end
+
+        it "counts dropped messages" do
+          proxy = SemanticLogger::Appender::Async.new(
+            appender:                       appender,
+            max_queue_size:                 2,
+            non_blocking:                   true,
+            dropped_message_report_seconds: 0
+          )
+
+          # Stop the worker thread so the queue is not drained while we fill it.
+          worker = proxy.instance_variable_get(:@thread)
+          worker.kill
+          worker.join
+
+          log = SemanticLogger::Log.new("Test", :info)
+          4.times { proxy.log(log) }
+
+          assert_equal 2, proxy.stats[:dropped]
+        ensure
+          proxy&.queue&.clear
+        end
+      end
+
       describe "non_blocking" do
         # Records warnings logged to the internal logger.
         let :recording_logger do

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -67,6 +67,25 @@ module SemanticLogger
         end
       end
 
+      describe "#stats" do
+        it "reports pipeline statistics including per-appender stats" do
+          stats = processor.stats
+
+          assert_kind_of Integer, stats[:queue_size]
+          assert_kind_of Integer, stats[:processed]
+          assert_equal 0, stats[:dropped]
+          assert_predicate processor, :active?
+          assert stats[:thread_active]
+          assert_kind_of Array, stats[:appenders]
+        end
+
+        it "includes an entry per appender" do
+          processor.appenders.add(io: StringIO.new)
+
+          assert_equal processor.appenders.size, processor.stats[:appenders].size
+        end
+      end
+
       describe "#start" do
         it "returns false when the worker thread is already active" do
           assert_predicate processor, :active?

--- a/test/semantic_logger_test.rb
+++ b/test/semantic_logger_test.rb
@@ -353,6 +353,20 @@ class SemanticLoggerTest < Minitest::Test
       end
     end
 
+    describe ".stats" do
+      it "delegates to the processor" do
+        expected  = {queue_size: 0, processed: 5, dropped: 0, appenders: []}
+        processor = Minitest::Mock.new
+        processor.expect(:stats, expected)
+
+        SemanticLogger::Logger.stub(:processor, processor) do
+          assert_equal expected, SemanticLogger.stats
+        end
+
+        processor.verify
+      end
+    end
+
     describe ".lag_check_interval" do
       it "reads and writes the value via the processor" do
         processor = Minitest::Mock.new


### PR DESCRIPTION
## Summary

Closes #164.

Adds `SemanticLogger.stats`, a Puma-style accessor that returns operational statistics about the logging pipeline so Semantic Logger's own health can be exported to a monitoring system such as Prometheus or statsd. No new gem dependency: it returns a plain Hash.

```ruby
SemanticLogger.stats
# => {
#      queue_size:     0, capped: true, max_queue_size: 10_000,
#      thread_active:  true,
#      processed:      1532,   # count of all log lines processed
#      dropped:        0,      # count of all rejected (dropped) log lines
#      appenders: [
#        { name: "...File", async: false },
#        { name: "...Http", async: true, queue_size: 3,
#          processed: 1529, dropped: 0, capped: true, max_queue_size: 10_000,
#          thread_active: true }
#      ]
#    }
```

This covers the three metrics requested in the issue (lines processed, lines dropped, queue sizes) for both the shared pipeline queue and each appender that runs its own async/batch thread.

## Changes

- `Appender::Async` — cumulative `processed`/`dropped` counters and a `#stats` method.
- `Appender::AsyncBatch` — increments `processed` by the batch size (counts log messages, not batches, for consistency with the rest of the pipeline).
- `Appenders#stats` — per-appender breakdown (`async: false` for inline appenders).
- `Processor#stats` / `SyncProcessor#stats` — pipeline-level stats.
- `SemanticLogger.stats` — public entry point (`queue_size` retained for back-compat).
- Docs added under "Monitoring the background log thread" in `docs/api.md`.

## Thread-safety / performance

Per the requirement on the issue:

- `processed` is incremented only on the single worker thread (one writer), so no locking is added to the logging hot path.
- `dropped` reuses the existing `@dropped_message_mutex` on the rare drop path.
- Reads tolerate slight staleness, which is fine for stats.

## Testing

- Full suite: 1282 tests, 0 failures (MongoDB tests skipped, no `MONGO_HOST`).
- Rubocop clean.
- Verified manually in both async and sync modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)