### PR TITLE
Add ECS (Elastic Common Schema) formatter (#295)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,6 +160,7 @@ Naming/VariableNumber:
     - 'lib/semantic_logger/appender/elasticsearch.rb'
     - 'lib/semantic_logger/appender/honeybadger_insights.rb'
     - 'lib/semantic_logger/formatters/base.rb'
+    - 'lib/semantic_logger/formatters/ecs.rb'
     - 'lib/semantic_logger/formatters/fluentd.rb'
     - 'lib/semantic_logger/formatters/json.rb'
     - 'lib/semantic_logger/formatters/logfmt.rb'

--- a/docs/appenders.md
+++ b/docs/appenders.md
@@ -226,6 +226,66 @@ formatter = SemanticLogger::Formatters::Fluentd.new(log_host: true, need_process
 SemanticLogger.add_appender(io: $stdout, formatter: formatter)
 ~~~
 
+#### ECS (Elastic Common Schema) log format
+
+The `:ecs` formatter emits each log event using the nested field names defined by
+the [Elastic Common Schema](https://www.elastic.co/docs/reference/ecs) (targeting
+ECS 8.x), so logs integrate cleanly with Filebeat and the Elastic stack
+(Elasticsearch, Kibana) without an ingest pipeline to rename fields.
+
+Like `:json`, it produces a single line of JSON per event, so it works with the
+appenders that write or post JSON: an IO stream (`io: $stdout`), a file
+(`file_name:`), and the HTTP appender. The typical deployment writes ECS JSON to
+stdout or a log file and lets Filebeat or Elastic Agent ship it to Elasticsearch:
+
+~~~ruby
+# Ship via Filebeat / Elastic Agent tailing stdout or a file:
+SemanticLogger.add_appender(io: $stdout, formatter: :ecs)
+SemanticLogger.add_appender(file_name: "production.log", formatter: :ecs)
+~~~
+
+The Semantic Logger fields are mapped to ECS as follows:
+
+| Semantic Logger | ECS |
+| :--- | :--- |
+| `time` | `@timestamp` |
+| `level` | `log.level` |
+| `name` | `log.logger` |
+| `file` / `line` | `log.origin.file.name` / `log.origin.file.line` |
+| `message` | `message` |
+| `thread` | `process.thread.name` |
+| `pid` | `process.pid` |
+| `host` | `host.hostname` |
+| `application` | `service.name` |
+| `environment` | `service.environment` |
+| `exception` | `error.type` / `error.message` / `error.stack_trace` |
+| `duration` | `event.duration` (nanoseconds) |
+| `tags` | `tags` |
+| `named_tags` | `labels.*` |
+| `payload`, `metric`, `metric_amount` | nested under a custom namespace (see below) |
+
+ECS reserves the top-level field names it defines, so Semantic Logger data that
+has no native ECS home (the `payload`, `metric`, and `metric_amount`) is nested
+under a custom top-level namespace, `semantic_logger` by default. A proper-noun
+namespace is [the approach ECS recommends](https://www.elastic.co/docs/reference/ecs/ecs-custom-fields-in-ecs)
+for custom fields, since it is guaranteed never to collide with a current or
+future ECS field.
+
+Use the `namespace:` option to rename it:
+
+~~~ruby
+formatter = SemanticLogger::Formatters::Ecs.new(namespace: "my_app")
+SemanticLogger.add_appender(io: $stdout, formatter: formatter)
+~~~
+
+Or set `namespace: nil` to merge the payload directly into ECS `labels` alongside
+the named tags:
+
+~~~ruby
+formatter = SemanticLogger::Formatters::Ecs.new(namespace: nil)
+SemanticLogger.add_appender(io: $stdout, formatter: formatter)
+~~~
+
 ### IO Streams
 
 Semantic Logger can log data to any IO Stream instance, such as $stderr or $stdout

--- a/lib/semantic_logger/formatters.rb
+++ b/lib/semantic_logger/formatters.rb
@@ -3,6 +3,7 @@ module SemanticLogger
     autoload :Base,          "semantic_logger/formatters/base"
     autoload :Color,         "semantic_logger/formatters/color"
     autoload :Default,       "semantic_logger/formatters/default"
+    autoload :Ecs,           "semantic_logger/formatters/ecs"
     autoload :Json,          "semantic_logger/formatters/json"
     autoload :Raw,           "semantic_logger/formatters/raw"
     autoload :OneLine,       "semantic_logger/formatters/one_line"

--- a/lib/semantic_logger/formatters/ecs.rb
+++ b/lib/semantic_logger/formatters/ecs.rb
@@ -1,0 +1,151 @@
+require "json"
+module SemanticLogger
+  module Formatters
+    # Formatter conforming to the Elastic Common Schema (ECS).
+    #
+    # Emits log events using the nested field names defined by ECS so that they
+    # integrate cleanly with Filebeat and the Elastic stack (Elasticsearch,
+    # Kibana) without requiring an ingest pipeline to rename fields.
+    #
+    # Usage:
+    #   SemanticLogger.add_appender(io: $stdout, formatter: :ecs)
+    #
+    #   # Route the payload, metric, and other SemanticLogger-specific data into
+    #   # a custom top-level namespace (default "semantic_logger"):
+    #   SemanticLogger.add_appender(io: $stdout, formatter: {ecs: {namespace: "my_app"}})
+    #
+    #   # Or merge the payload directly into ECS `labels` instead of a namespace:
+    #   SemanticLogger.add_appender(io: $stdout, formatter: {ecs: {namespace: nil}})
+    #
+    # == Field mapping (SemanticLogger -> ECS 8.x)
+    #   time                  -> @timestamp        (ISO-8601)
+    #   level                 -> log.level
+    #   name                  -> log.logger
+    #   file_name / line      -> log.origin.file.name / log.origin.file.line
+    #   message               -> message
+    #   thread_name           -> process.thread.name
+    #   pid                   -> process.pid
+    #   host                  -> host.hostname
+    #   application           -> service.name
+    #   environment           -> service.environment
+    #   exception             -> error.type / error.message / error.stack_trace
+    #   duration              -> event.duration   (nanoseconds, as required by ECS)
+    #   tags                  -> tags             (ECS top-level array)
+    #   named_tags            -> labels.*         (scalar key/value pairs)
+    #   payload               -> <namespace>.*    (or labels.* when namespace is nil)
+    #   metric/metric_amount  -> <namespace>.metric / <namespace>.metric_amount
+    #
+    # == Reference
+    #   * https://www.elastic.co/docs/reference/ecs
+    #   * https://www.elastic.co/docs/reference/ecs/ecs-custom-fields-in-ecs
+    class Ecs < Raw
+      # ECS version this formatter targets.
+      ECS_VERSION = "8.11.0".freeze
+
+      # namespace: [String|Symbol|nil]
+      #   Top-level field set used to hold SemanticLogger-specific data that has
+      #   no native ECS home (payload, metric, metric_amount). A proper-noun
+      #   namespace is guaranteed never to collide with a current or future ECS
+      #   field. Set to nil to merge the payload into ECS `labels` instead.
+      #   Default: "semantic_logger"
+      attr_reader :namespace
+
+      def initialize(namespace: "semantic_logger", time_format: :iso_8601, time_key: :timestamp, **args)
+        @namespace = namespace&.to_sym
+
+        super(time_format: time_format, time_key: time_key, **args)
+      end
+
+      # Returns the log event as a single line of ECS-formatted JSON, so it can
+      # be written to stdout / a file and shipped by Filebeat or Elastic Agent.
+      def call(log, logger)
+        Utils.to_json(ecs_hash(super))
+      end
+
+      # Returns a batch of log events as a single JSON array.
+      def batch(logs, logger)
+        "[#{logs.map { |log| call(log, logger) }.join(',')}]"
+      end
+
+      private
+
+      # Remap the flat hash built by Raw#call into the nested ECS field layout.
+      def ecs_hash(hash)
+        result = base(hash)
+        result[:process] = process(hash)
+        result[:host]    = {hostname: hash[:host]} if hash[:host]
+        add_service(result, hash)
+        add_origin(result, hash)
+        add_event(result, hash)
+        result[:tags] = hash[:tags] if hash[:tags]
+        add_error(result, hash)
+        add_extras(result, hash)
+        result
+      end
+
+      def base(hash)
+        log = {level: hash[:level].to_s}
+        log[:logger] = hash[:name] if hash[:name]
+        {
+          "@timestamp": hash[:timestamp],
+          message:      hash[:message],
+          ecs:          {version: ECS_VERSION},
+          log:          log
+        }
+      end
+
+      def process(hash)
+        result = {pid: hash[:pid]}
+        result[:thread] = {name: hash[:thread].to_s} if hash[:thread]
+        result
+      end
+
+      def add_service(result, hash)
+        service = {}
+        service[:name]        = hash[:application] if hash[:application]
+        service[:environment] = hash[:environment] if hash[:environment]
+        result[:service] = service unless service.empty?
+      end
+
+      def add_origin(result, hash)
+        return unless hash[:file]
+
+        result[:log][:origin] = {file: {name: hash[:file], line: hash[:line]}.compact}
+      end
+
+      # ECS event.duration is measured in nanoseconds.
+      def add_event(result, hash)
+        return unless hash[:duration_ms]
+
+        result[:event] = {duration: (hash[:duration_ms] * 1_000_000).round}
+      end
+
+      def add_error(result, hash)
+        return unless hash[:exception]
+
+        result[:error] = {
+          type:        hash[:exception][:name],
+          message:     hash[:exception][:message],
+          stack_trace: Array(hash[:exception][:stack_trace]).join("\n")
+        }
+      end
+
+      # Place SemanticLogger-specific data (payload, metric) that has no native
+      # ECS home into the configured namespace, plus named_tags into labels.
+      def add_extras(result, hash)
+        labels = hash[:named_tags].is_a?(Hash) ? hash[:named_tags].dup : {}
+
+        extra = {}
+        extra[:payload]       = hash[:payload] if hash[:payload]
+        extra[:metric]        = hash[:metric] if hash[:metric]
+        extra[:metric_amount] = hash[:metric_amount] if hash[:metric_amount]
+
+        unless extra.empty?
+          namespace ? result[namespace] = extra : labels.merge!(extra)
+        end
+
+        result[:labels] = labels unless labels.empty?
+      end
+    end
+  end
+end

--- a/test/formatters/ecs_test.rb
+++ b/test/formatters/ecs_test.rb
@@ -1,0 +1,184 @@
+require_relative "../test_helper"
+
+module SemanticLogger
+  module Formatters
+    class EcsTest < Minitest::Test
+      describe Ecs do
+        let(:log_time) do
+          Time.utc(2017, 1, 14, 8, 32, 5.375276)
+        end
+
+        let(:level) do
+          :debug
+        end
+
+        let(:log) do
+          log      = SemanticLogger::Log.new("EcsTest", level)
+          log.time = log_time
+          log
+        end
+
+        # Stand-in for the appender / subscriber that owns host/application/environment.
+        let(:appender) do
+          Struct.new(:host, :application, :environment).new("test_host", "test_app", "test_env")
+        end
+
+        let(:formatter) do
+          SemanticLogger::Formatters::Ecs.new
+        end
+
+        let(:result) do
+          JSON.parse(formatter.call(log, appender), symbolize_names: true)
+        end
+
+        describe "core fields" do
+          it "emits an ISO-8601 @timestamp" do
+            assert_equal "2017-01-14T08:32:05.375276Z", result[:@timestamp]
+          end
+
+          it "emits the ecs version" do
+            assert_equal SemanticLogger::Formatters::Ecs::ECS_VERSION, result.dig(:ecs, :version)
+          end
+
+          it "emits the level and logger name" do
+            assert_equal "debug", result.dig(:log, :level)
+            assert_equal "EcsTest", result.dig(:log, :logger)
+          end
+
+          it "emits the message" do
+            log.message = "Hello World"
+
+            assert_equal "Hello World", result[:message]
+          end
+        end
+
+        describe "process, host, service" do
+          it "maps pid and thread name under process" do
+            assert_kind_of Integer, result.dig(:process, :pid)
+            assert_equal Thread.current.name.to_s, result.dig(:process, :thread, :name) if Thread.current.name
+          end
+
+          it "maps host to host.hostname" do
+            assert_equal "test_host", result.dig(:host, :hostname)
+          end
+
+          it "maps application and environment to service" do
+            assert_equal "test_app", result.dig(:service, :name)
+            assert_equal "test_env", result.dig(:service, :environment)
+          end
+        end
+
+        describe "duration" do
+          it "converts milliseconds to event.duration in nanoseconds" do
+            log.duration = 1.5
+
+            assert_equal 1_500_000, result.dig(:event, :duration)
+          end
+
+          it "omits event.duration when not set" do
+            refute result.key?(:event)
+          end
+        end
+
+        describe "tags and named_tags" do
+          it "emits tags as a top-level array" do
+            log.tags = %w[first second]
+
+            assert_equal %w[first second], result[:tags]
+          end
+
+          it "maps named_tags to labels" do
+            log.named_tags = {user_id: 5, account: "acme"}
+
+            assert_equal({user_id: 5, account: "acme"}, result[:labels])
+          end
+
+          it "omits labels when empty" do
+            refute result.key?(:labels)
+          end
+        end
+
+        describe "exception" do
+          it "maps to error.type / error.message / error.stack_trace" do
+            begin
+              raise "Oh no"
+            rescue StandardError => e
+              log.exception = e
+            end
+
+            assert_equal "RuntimeError", result.dig(:error, :type)
+            assert_equal "Oh no", result.dig(:error, :message)
+            assert_kind_of String, result.dig(:error, :stack_trace)
+          end
+
+          it "omits error when not set" do
+            refute result.key?(:error)
+          end
+        end
+
+        describe "namespace for non-ECS data" do
+          it "nests payload, metric, and metric_amount under the default namespace" do
+            log.payload       = {first: 1, second: 2}
+            log.metric        = "users/registered"
+            log.metric_amount = 3
+
+            assert_equal({first: 1, second: 2}, result.dig(:semantic_logger, :payload))
+            assert_equal "users/registered", result.dig(:semantic_logger, :metric)
+            assert_equal 3, result.dig(:semantic_logger, :metric_amount)
+          end
+
+          it "uses a custom namespace" do
+            formatter = SemanticLogger::Formatters::Ecs.new(namespace: "my_app")
+            log.payload = {first: 1}
+            parsed = JSON.parse(formatter.call(log, appender), symbolize_names: true)
+
+            assert_equal({first: 1}, parsed.dig(:my_app, :payload))
+          end
+
+          it "merges payload into labels when namespace is nil" do
+            formatter = SemanticLogger::Formatters::Ecs.new(namespace: nil)
+            log.payload    = {first: 1}
+            log.named_tags = {user_id: 5}
+            parsed = JSON.parse(formatter.call(log, appender), symbolize_names: true)
+
+            assert_equal 1, parsed.dig(:labels, :payload, :first)
+            assert_equal 5, parsed.dig(:labels, :user_id)
+            refute parsed.key?(:semantic_logger)
+          end
+
+          it "omits the namespace when there is no extra data" do
+            refute result.key?(:semantic_logger)
+          end
+        end
+
+        describe "JSON encoding" do
+          it "returns a single line of valid JSON" do
+            log.message    = "Hello World"
+            log.payload    = {first: 1}
+            log.named_tags = {user_id: 5}
+
+            json = formatter.call(log, appender)
+
+            assert_kind_of String, json
+            refute_includes json, "\n"
+
+            parsed = JSON.parse(json)
+
+            assert_equal "Hello World", parsed["message"]
+            assert_equal SemanticLogger::Formatters::Ecs::ECS_VERSION, parsed.dig("ecs", "version")
+            assert_equal 1, parsed.dig("semantic_logger", "payload", "first")
+            assert_equal 5, parsed.dig("labels", "user_id")
+          end
+
+          it "batches events into a JSON array" do
+            json = formatter.batch([log, log], appender)
+            parsed = JSON.parse(json)
+
+            assert_equal 2, parsed.size
+            assert_equal "debug", parsed.first.dig("log", "level")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #295.

Adds a `:ecs` formatter that emits each log event using the nested field names defined by the [Elastic Common Schema](https://www.elastic.co/docs/reference/ecs) (targeting ECS 8.x), so logs integrate cleanly with Filebeat / Elastic Agent and the Elastic stack (Elasticsearch, Kibana) without an ingest pipeline to rename fields.

```ruby
SemanticLogger.add_appender(io: $stdout, formatter: :ecs)
```

## Design

- **Returns a JSON string** (like `:json`/`:fluentd`), one line per event, so it works with the appenders that write/post JSON: IO (`io: $stdout`), File (`file_name:`), and HTTP. The typical deployment writes ECS JSON to stdout/a file and lets Filebeat or Elastic Agent ship it to Elasticsearch.
- **Custom namespace for non-ECS data.** ECS reserves its top-level field names, so Semantic Logger data with no native ECS home (`payload`, `metric`, `metric_amount`) is nested under a configurable top-level namespace (default `"semantic_logger"`), which is [the approach ECS recommends](https://www.elastic.co/docs/reference/ecs/ecs-custom-fields-in-ecs) for custom fields. Configure with `Ecs.new(namespace: "my_app")`, or `namespace: nil` to merge the payload into ECS `labels`.

## Field mapping (Semantic Logger → ECS 8.x)

| Semantic Logger | ECS |
| :--- | :--- |
| `time` | `@timestamp` |
| `level` | `log.level` |
| `name` | `log.logger` |
| `file` / `line` | `log.origin.file.name` / `log.origin.file.line` |
| `message` | `message` |
| `thread` | `process.thread.name` |
| `pid` | `process.pid` |
| `host` | `host.hostname` |
| `application` | `service.name` |
| `environment` | `service.environment` |
| `exception` | `error.type` / `error.message` / `error.stack_trace` |
| `duration` | `event.duration` (nanoseconds) |
| `tags` | `tags` |
| `named_tags` | `labels.*` |
| `payload`, `metric`, `metric_amount` | nested under the namespace |

Example output:

```json
{"@timestamp":"2026-06-23T18:04:34.808569Z","message":"Processed order","ecs":{"version":"8.11.0"},"log":{"level":"info","logger":"MyApp::Worker"},"process":{"pid":17897,"thread":{"name":"1224"}},"host":{"hostname":"web1"},"service":{"name":"shop","environment":"production"},"event":{"duration":7000},"semantic_logger":{"payload":{"order_id":42}},"labels":{"request_id":"abc123"}}
```

## Changes

- New `lib/semantic_logger/formatters/ecs.rb` (subclasses `Raw`, remaps to ECS, returns JSON), registered in the `Formatters` autoload list.
- `test/formatters/ecs_test.rb` covering field mapping, duration conversion, exception, all three namespace modes, JSON encoding, and batching.
- Docs: new "ECS (Elastic Common Schema) log format" section in `docs/appenders.md`.
- `.rubocop_todo.yml`: add `ecs.rb` to the existing `Naming/VariableNumber` exclusion list (shared `:iso_8601` symbol convention, same as `json.rb`/`logfmt.rb`).

## Notes / follow-ups
- The bulk `:elasticsearch` appender's default formatter returns a Hash; this string-returning ECS formatter is not a drop-in for it. The `:elasticsearch_http` appender posts a JSON string, so `formatter: :ecs` works there. Existing Elasticsearch appender defaults are intentionally left unchanged (changing the indexed document shape would break existing mappings/dashboards).
- `error.stack_trace` uses the top-level exception only (nested causes are not separately emitted, ECS has no clean nested-cause field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)