### PR TITLE
Add retry-with-backoff to the async worker thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add retry-with-backoff for the asynchronous worker thread. When an appender raises while
   processing messages, the thread restarts with an increasing back-off and stops after
   `async_max_retries` (default `100`) consecutive failures instead of retrying forever. The
-  counter resets after any message is processed successfully.
+  counter resets after any message is processed successfully. Set `async_max_retries: -1` to
+  restore the previous behaviour of retrying indefinitely.
 - Add per-logger (child logger) tags: calling `logger.tagged(...)` (or `with_tags`) without a
   block now returns a new logger instance that permanently carries the supplied positional and/or
   named tags, scoped to that logger only. Resolves #165. Combines the approaches from #301 (theocodes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   internal `SemanticLogger::QueueProcessor`, and `SemanticLogger::Appender::AsyncBatch` has been
   removed. `batch: true` now returns a `SemanticLogger::Appender::Async` (with `#batch?` true).
   See the v5.0 upgrading guide.
+- Add retry-with-backoff for the asynchronous worker thread. When an appender raises while
+  processing messages, the thread restarts with an increasing back-off and stops after
+  `async_max_retries` (default `100`) consecutive failures instead of retrying forever. The
+  counter resets after any message is processed successfully.
 - Add per-logger (child logger) tags: calling `logger.tagged(...)` (or `with_tags`) without a
   block now returns a new logger instance that permanently carries the supplied positional and/or
   named tags, scoped to that logger only. Resolves #165. Combines the approaches from #301 (theocodes)

--- a/docs/index.md
+++ b/docs/index.md
@@ -210,6 +210,25 @@ SemanticLogger.add_appender(
 `non_blocking` only applies to a capped queue; an uncapped queue (`max_queue_size: -1`) never
 blocks and never drops, but can grow without bound.
 
+### Worker thread retries
+
+If an appender raises while the background worker thread is writing a message, the thread logs the
+error and restarts so that a transient failure (for example a brief network blip for a remote
+appender) does not permanently stop logging. Each restart first sleeps with an increasing back-off
+(1 second, then 2, ...), and the count resets as soon as a message is processed successfully.
+
+After `async_max_retries` (default `100`) consecutive failed restarts the worker thread stops
+instead of restarting, to avoid spinning forever on a persistent failure:
+
+~~~ruby
+SemanticLogger.add_appender(
+  appender:          :http,
+  url:               "https://example.com/log",
+  async:             true,
+  async_max_retries: 20
+)
+~~~
+
 ### Ruby Support
 
 For the complete list of supported Ruby versions, see

--- a/docs/index.md
+++ b/docs/index.md
@@ -229,6 +229,13 @@ SemanticLogger.add_appender(
 )
 ~~~
 
+To restore the previous behaviour of retrying indefinitely (never giving up), set
+`async_max_retries: -1`. The back-off still applies and still resets after a successful message:
+
+~~~ruby
+SemanticLogger.add_appender(file_name: "production.log", async: true, async_max_retries: -1)
+~~~
+
 ### Ruby Support
 
 For the complete list of supported Ruby versions, see

--- a/lib/semantic_logger/appender.rb
+++ b/lib/semantic_logger/appender.rb
@@ -36,6 +36,7 @@ module SemanticLogger
                      max_queue_size: 10_000, lag_check_interval: 1_000, lag_threshold_s: 30,
                      batch_size: 300, batch_seconds: 5,
                      non_blocking: false, dropped_message_report_seconds: 30,
+                     async_max_retries: 100,
                      **args,
                      &)
       appender = build(**args, &)
@@ -53,7 +54,8 @@ module SemanticLogger
           batch_size:                     batch_size,
           batch_seconds:                  batch_seconds,
           non_blocking:                   non_blocking,
-          dropped_message_report_seconds: dropped_message_report_seconds
+          dropped_message_report_seconds: dropped_message_report_seconds,
+          async_max_retries:              async_max_retries
         )
       elsif async == true
         Appender::Async.new(
@@ -62,7 +64,8 @@ module SemanticLogger
           lag_check_interval:             lag_check_interval,
           lag_threshold_s:                lag_threshold_s,
           non_blocking:                   non_blocking,
-          dropped_message_report_seconds: dropped_message_report_seconds
+          dropped_message_report_seconds: dropped_message_report_seconds,
+          async_max_retries:              async_max_retries
         )
       else
         appender

--- a/lib/semantic_logger/appender/async.rb
+++ b/lib/semantic_logger/appender/async.rb
@@ -75,6 +75,12 @@ module SemanticLogger
       #     When non_blocking is enabled, log the count of dropped messages to the internal logger
       #     at most once every this number of seconds.
       #     Default: 30
+      #
+      #   async_max_retries: [Integer]
+      #     Maximum number of consecutive times to restart the worker thread (with a back-off)
+      #     after it raises an exception while processing messages, before giving up and stopping
+      #     the thread. The counter resets after any message is processed successfully.
+      #     Default: 100
       def initialize(appender:, **args)
         @appender  = appender
         @processor = QueueProcessor.start(appender: appender, **args)

--- a/lib/semantic_logger/appender/async.rb
+++ b/lib/semantic_logger/appender/async.rb
@@ -80,6 +80,7 @@ module SemanticLogger
       #     Maximum number of consecutive times to restart the worker thread (with a back-off)
       #     after it raises an exception while processing messages, before giving up and stopping
       #     the thread. The counter resets after any message is processed successfully.
+      #     -1: Retry indefinitely and never stop the thread (the pre-v5 behaviour).
       #     Default: 100
       def initialize(appender:, **args)
         @appender  = appender

--- a/lib/semantic_logger/queue_processor.rb
+++ b/lib/semantic_logger/queue_processor.rb
@@ -14,7 +14,7 @@ module SemanticLogger
     attr_accessor :lag_check_interval, :lag_threshold_s, :dropped_message_report_seconds,
                   :batch_size, :batch_seconds
     attr_reader :appender, :queue, :max_queue_size, :non_blocking, :signal,
-                :processed_count, :dropped_count
+                :processed_count, :dropped_count, :async_max_retries, :retry_count
 
     # Create a new processor and start its worker thread.
     def self.start(**args)
@@ -65,6 +65,14 @@ module SemanticLogger
     #     When non_blocking is enabled, log the count of dropped messages to the internal logger
     #     at most once every this number of seconds.
     #     Default: 30
+    #
+    #   async_max_retries: [Integer]
+    #     Maximum number of consecutive times to restart the worker thread after it raises an
+    #     exception while processing messages. Each restart first sleeps for `retry_count` seconds
+    #     (1s, then 2s, ...) as a back-off. Once this many consecutive retries are exhausted the
+    #     thread stops instead of restarting. The counter resets to zero whenever a message is
+    #     processed successfully.
+    #     Default: 100
     def initialize(appender:,
                    max_queue_size: 10_000,
                    lag_check_interval: 1_000,
@@ -73,7 +81,8 @@ module SemanticLogger
                    batch_size: 300,
                    batch_seconds: 5,
                    non_blocking: false,
-                   dropped_message_report_seconds: 30)
+                   dropped_message_report_seconds: 30,
+                   async_max_retries: 100)
       @appender                       = appender
       @max_queue_size                 = max_queue_size
       @lag_check_interval             = lag_check_interval
@@ -83,6 +92,8 @@ module SemanticLogger
       @batch_seconds                  = batch_seconds
       @non_blocking                   = non_blocking
       @dropped_message_report_seconds = dropped_message_report_seconds
+      @async_max_retries              = async_max_retries
+      @retry_count                    = 0
       @thread                         = nil
       # Only batch mode parks the worker on the signal; streaming mode never touches it.
       @signal                         = Concurrent::Event.new if batch
@@ -109,7 +120,7 @@ module SemanticLogger
     def thread
       return @thread if @thread&.alive?
 
-      @thread = Thread.new { process }
+      @thread = spawn_worker
     end
 
     # Returns [true|false] whether the worker thread is running.
@@ -177,10 +188,18 @@ module SemanticLogger
       create_queue
 
       @thread&.kill if @thread&.alive?
-      @thread = Thread.new { process }
+      @thread = spawn_worker
     end
 
     private
+
+    # Start the worker thread, naming it after the internal logger.
+    def spawn_worker
+      Thread.new do
+        Thread.current.name = logger.name
+        process
+      end
+    end
 
     def create_queue
       if max_queue_size == -1
@@ -196,13 +215,18 @@ module SemanticLogger
     def process
       # This thread is designed to never go down unless the main thread terminates
       # or the appender is closed.
-      Thread.current.name = logger.name
       logger.trace "Async: Appender thread active"
       begin
         batch? ? process_messages_in_batches : process_messages
       rescue StandardError => e
-        safe_log(:error, "Async: Restarting due to exception", e)
-        retry
+        if retry_count < async_max_retries
+          @retry_count += 1
+          safe_log(:warn, "Async: Restarting due to exception, retry #{retry_count} of #{async_max_retries}, sleeping #{retry_count}s", e)
+          sleep(retry_count)
+          retry
+        else
+          safe_log(:error, "Async: Stopping after #{retry_count} failed retries", e)
+        end
       rescue Exception => e
         safe_log(:error, "Async: Stopping due to fatal exception", e)
       ensure
@@ -226,6 +250,7 @@ module SemanticLogger
         if message.is_a?(Log)
           appender.log(message)
           @processed_count += 1
+          @retry_count = 0 unless retry_count.zero?
           count += 1
           # Check every few log messages whether this appender thread is falling behind
           if count > lag_check_interval
@@ -265,6 +290,7 @@ module SemanticLogger
         if logs.size.positive?
           appender.batch(logs)
           @processed_count += logs.size
+          @retry_count = 0 unless retry_count.zero?
         end
         # Stop processing once a command (e.g. :close) signals the thread to terminate.
         break if messages.any? { |message| !process_message(message) }

--- a/lib/semantic_logger/queue_processor.rb
+++ b/lib/semantic_logger/queue_processor.rb
@@ -72,6 +72,8 @@ module SemanticLogger
     #     (1s, then 2s, ...) as a back-off. Once this many consecutive retries are exhausted the
     #     thread stops instead of restarting. The counter resets to zero whenever a message is
     #     processed successfully.
+    #     -1: Retry indefinitely and never stop the thread (the pre-v5 behaviour). The back-off
+    #         still applies, and still resets after any successful message.
     #     Default: 100
     def initialize(appender:,
                    max_queue_size: 10_000,
@@ -219,9 +221,10 @@ module SemanticLogger
       begin
         batch? ? process_messages_in_batches : process_messages
       rescue StandardError => e
-        if retry_count < async_max_retries
+        if async_max_retries == -1 || retry_count < async_max_retries
           @retry_count += 1
-          safe_log(:warn, "Async: Restarting due to exception, retry #{retry_count} of #{async_max_retries}, sleeping #{retry_count}s", e)
+          limit = async_max_retries == -1 ? "unlimited" : async_max_retries
+          safe_log(:warn, "Async: Restarting due to exception, retry #{retry_count} of #{limit}, sleeping #{retry_count}s", e)
           sleep(retry_count)
           retry
         else

--- a/test/queue_processor_test.rb
+++ b/test/queue_processor_test.rb
@@ -29,6 +29,9 @@ class QueueProcessorTest < Minitest::Test
     end
   end
 
+  # A non-StandardError exception, used to exercise the fatal (non-retryable) path in #process.
+  class FatalError < Exception; end # rubocop:disable Lint/InheritException
+
   describe SemanticLogger::QueueProcessor do
     let(:internal_logger) { SemanticLogger::Test::CaptureLogEvents.new }
 
@@ -157,6 +160,75 @@ class QueueProcessorTest < Minitest::Test
         processor.send(:process_messages)
 
         assert_equal 1, processor.processed_count
+      end
+    end
+
+    describe "#process retry-with-backoff" do
+      it "retries on StandardError up to async_max_retries, then stops" do
+        processor = build(async_max_retries: 2)
+        attempts  = 0
+        boom      = lambda do
+          attempts += 1
+          raise "boom"
+        end
+
+        processor.stub(:sleep, nil) do
+          processor.stub(:process_messages, boom) do
+            processor.send(:process)
+          end
+        end
+
+        assert_equal 3, attempts, "expected initial attempt + 2 retries"
+        assert_equal 2, processor.retry_count
+
+        messages = internal_logger.events.map(&:message)
+        retries  = messages.count { |m| m.include?("Restarting due to exception, retry") }
+
+        assert_equal 2, retries
+        assert(messages.any? { |m| m.include?("Stopping after 2 failed retries") })
+      end
+
+      it "sleeps with an increasing back-off between retries" do
+        processor = build(async_max_retries: 3)
+        slept     = []
+
+        processor.stub(:sleep, ->(seconds) { slept << seconds }) do
+          processor.stub(:process_messages, -> { raise "boom" }) do
+            processor.send(:process)
+          end
+        end
+
+        assert_equal [1, 2, 3], slept
+      end
+
+      it "resets the retry count after a message is processed successfully" do
+        processor = build(async_max_retries: 5)
+        processor.instance_variable_set(:@retry_count, 3)
+        processor.queue << new_log
+        processor.queue << {command: :close}
+
+        processor.send(:process_messages)
+
+        assert_equal 0, processor.retry_count
+      end
+
+      it "stops immediately, without retrying, on a non-StandardError exception" do
+        processor = build(async_max_retries: 5)
+        attempts  = 0
+        fatal     = lambda do
+          attempts += 1
+          raise FatalError, "fatal"
+        end
+
+        processor.stub(:sleep, nil) do
+          processor.stub(:process_messages, fatal) do
+            processor.send(:process)
+          end
+        end
+
+        assert_equal 1, attempts
+        assert_equal 0, processor.retry_count
+        assert(internal_logger.events.map(&:message).any? { |m| m.include?("fatal exception") })
       end
     end
 

--- a/test/queue_processor_test.rb
+++ b/test/queue_processor_test.rb
@@ -188,6 +188,27 @@ class QueueProcessorTest < Minitest::Test
         assert(messages.any? { |m| m.include?("Stopping after 2 failed retries") })
       end
 
+      it "retries indefinitely when async_max_retries is -1" do
+        processor = build(async_max_retries: -1)
+        attempts  = 0
+        # Raise on the first 5 attempts, then return normally to end processing.
+        flaky     = lambda do
+          attempts += 1
+          raise "boom" if attempts <= 5
+        end
+
+        processor.stub(:sleep, nil) do
+          processor.stub(:process_messages, flaky) do
+            processor.send(:process)
+          end
+        end
+
+        assert_equal 6, attempts
+        messages = internal_logger.events.map(&:message)
+
+        refute(messages.any? { |m| m.include?("Stopping after") }, "must not give up when retries are unlimited")
+      end
+
       it "sleeps with an increasing back-off between retries" do
         processor = build(async_max_retries: 3)
         slept     = []


### PR DESCRIPTION
Stacked on top of #357 (base: `refactor/async-queue-processor`).

## Summary

Adds retry-with-backoff to the `QueueProcessor` worker thread, replacing the previous "retry forever on `StandardError`" loop (a feature originally sketched in the long-closed refactor PR).

When an appender raises while the worker thread is processing messages:
- the thread restarts with an **increasing back-off** (sleep 1s, then 2s, …),
- and **stops after `async_max_retries` consecutive failures** (default `100`) instead of retrying forever.
- The retry counter **resets after any message is processed successfully**, so the limit applies to *consecutive* failures, not lifetime failures.

`async_max_retries` is configurable via `SemanticLogger.add_appender` and flows through `Appender.factory` → `Async` → `QueueProcessor`.

## Why the behavior change is safe

The previous behavior (retry forever) could spin indefinitely on a persistent appender failure. The new behavior bounds that while still tolerating transient failures (e.g. a brief network blip for a remote appender), thanks to the reset-on-success. Default of 100 consecutive failures is generous.

## Incidental fix

Moved the worker-thread naming (`Thread.current.name = logger.name`) out of `#process` and into the thread spawn (new private `#spawn_worker`). `#process` no longer renames the *calling* thread — correct, since in production it only ever runs on the worker thread, and it lets the new unit tests drive `#process` synchronously without polluting the main test thread's name (which otherwise broke unrelated thread-name assertions across the suite).

## Testing

- New `QueueProcessor` tests cover: retry up to the limit then stop, increasing back-off sequence, counter reset on success, and immediate stop on a non-`StandardError` exception (`sleep` is stubbed, so the tests are fast and deterministic).
- Full suite: **0 failures** in async (verified across multiple seeds, since this work surfaced and fixed an order-dependent pollution) and `LOGGER_SYNC=1` sync modes.
- RuboCop clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)