### PR TITLE
Add opt-in logger caching to SemanticLogger[]

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -83,6 +83,38 @@ All logger instances forward their log messages to the global Appender Thread th
 does the actual logging to each appender, see [Appenders](appenders.html) for a list of available
 Appenders.
 
+#### Caching loggers
+
+By default `SemanticLogger[...]` returns a brand new logger instance on every
+call. Enable logger caching to have a single shared logger returned per class:
+
+~~~ruby
+SemanticLogger.cache_loggers = true
+
+SemanticLogger[MyClass].equal?(SemanticLogger[MyClass]) # => true
+~~~
+
+This makes it possible to obtain a logger once and later change its level (or
+filter) so that every holder of that logger sees the change:
+
+~~~ruby
+SemanticLogger[MyClass].level = :debug
+~~~
+
+Notes:
+
+- Caching is **opt-in** and disabled by default.
+- Only Classes and Modules are cached. A String always returns a new instance,
+  since string call sites commonly want an independent logger (for example to
+  set a different level per call site).
+- Anonymous classes (those without a name) are never cached.
+- With caching enabled, `SemanticLogger[MyClass]` and the
+  [`SemanticLogger::Loggable`](#using-the-semanticloggerloggable-mixin) mixin's
+  `MyClass.logger` return the same instance.
+- Setting `SemanticLogger.cache_loggers = false` clears the cache. It can also be
+  cleared explicitly with `SemanticLogger.clear_logger_cache`, for example after
+  redefining a class.
+
 #### Using the SemanticLogger::Loggable Mixin
 
 Rather than creating logger instances above inside classes it is recommended to

--- a/lib/semantic_logger/semantic_logger.rb
+++ b/lib/semantic_logger/semantic_logger.rb
@@ -4,9 +4,42 @@ module SemanticLogger
   # Logging levels in order of most detailed to most severe
   LEVELS = Levels::LEVELS
 
-  # Return a logger for the supplied class or class_name
+  # Return a logger for the supplied class or class_name.
+  #
+  # When `SemanticLogger.cache_loggers` is enabled (opt-in, default off) and a
+  # Class or Module is supplied, the same Logger instance is returned for every
+  # call with that class. This makes it possible to obtain a logger once and
+  # later change its level (or filter) and have every holder of that logger see
+  # the change.
+  #
+  # A String is always given its own new Logger instance, even when caching is
+  # enabled: callers that pass a string typically want an independent logger
+  # (for example to set a different level per call site). Anonymous classes
+  # (those with no `name`) are never cached, to avoid pinning short-lived
+  # dynamically created classes in memory.
   def self.[](klass)
-    Logger.new(klass)
+    return Logger.new(klass) if !@cache_loggers || klass.is_a?(String) || klass.name.nil?
+
+    logger_cache.compute_if_absent(klass) { Logger.new(klass) }
+  end
+
+  # Whether `SemanticLogger[Class]` returns a shared, cached Logger instance per
+  # class. Disabled by default. Strings are never cached (see #[]).
+  def self.cache_loggers=(cache_loggers)
+    @cache_loggers = cache_loggers
+    clear_logger_cache unless cache_loggers
+  end
+
+  # Returns whether logger caching is enabled.
+  def self.cache_loggers?
+    @cache_loggers
+  end
+
+  # Discard all cached loggers so that subsequent `SemanticLogger[Class]` calls
+  # build fresh instances. Primarily useful in tests, or after redefining a
+  # class that was previously cached.
+  def self.clear_logger_cache
+    @logger_cache&.clear
   end
 
   # Sets the global default log level
@@ -566,6 +599,14 @@ module SemanticLogger
   @backtrace_level       = :error
   @backtrace_level_index = Levels.index(@backtrace_level)
   @sync                  = false
+  @cache_loggers         = false
+  @logger_cache          = nil
+
+  # Lazily initialized thread-safe cache of one Logger per Class/Module.
+  def self.logger_cache
+    @logger_cache ||= Concurrent::Map.new
+  end
+  private_class_method :logger_cache
 
   # @formatter:off
   module Metric

--- a/test/semantic_logger_test.rb
+++ b/test/semantic_logger_test.rb
@@ -1,8 +1,81 @@
 require_relative "test_helper"
 
+# A named class used as a logger cache key in the ".[]" tests.
+class CachedSample
+  include SemanticLogger::Loggable
+end
+
 class SemanticLoggerTest < Minitest::Test
   describe SemanticLogger do
     let(:logger) { SemanticLogger["TestLogger"] }
+
+    describe ".[]" do
+      after do
+        SemanticLogger.cache_loggers = false
+      end
+
+      it "returns a new instance for a string" do
+        refute_same SemanticLogger["MyClass"], SemanticLogger["MyClass"]
+      end
+
+      it "returns a new instance for a class when caching is disabled" do
+        refute_predicate SemanticLogger, :cache_loggers?
+        refute_same SemanticLogger[CachedSample], SemanticLogger[CachedSample]
+      end
+
+      describe "with caching enabled" do
+        before do
+          SemanticLogger.cache_loggers = true
+        end
+
+        it "returns the same instance for a class" do
+          assert_same SemanticLogger[CachedSample], SemanticLogger[CachedSample]
+        end
+
+        it "still returns a new instance for a string" do
+          refute_same SemanticLogger["MyClass"], SemanticLogger["MyClass"]
+        end
+
+        it "does not cache anonymous classes" do
+          anonymous = Class.new
+
+          refute_same SemanticLogger[anonymous], SemanticLogger[anonymous]
+        end
+
+        it "shares level changes across holders of the cached logger" do
+          one = SemanticLogger[CachedSample]
+          two = SemanticLogger[CachedSample]
+          one.level = :trace
+
+          assert_equal :trace, two.level
+        ensure
+          one&.level = nil
+        end
+
+        it "builds fresh instances after the cache is cleared" do
+          first = SemanticLogger[CachedSample]
+          SemanticLogger.clear_logger_cache
+
+          refute_same first, SemanticLogger[CachedSample]
+        end
+
+        it "shares the cached logger with the Loggable mixin" do
+          CachedSample.instance_variable_set(:@semantic_logger, nil)
+
+          assert_same SemanticLogger[CachedSample], CachedSample.logger
+        ensure
+          CachedSample.instance_variable_set(:@semantic_logger, nil)
+        end
+      end
+
+      it "clears the cache and returns fresh instances after disabling" do
+        SemanticLogger.cache_loggers = true
+        cached = SemanticLogger[CachedSample]
+        SemanticLogger.cache_loggers = false
+
+        refute_same cached, SemanticLogger[CachedSample]
+      end
+    end
 
     describe ".add_appender" do
       before do


### PR DESCRIPTION
## Summary

`SemanticLogger[]` previously allocated a brand new `Logger` on every call, so the original intent of "create a logger once, reuse it later, and adjust its level" was never actually realized. This adds **opt-in** logger caching.

- New `SemanticLogger.cache_loggers` (default `false`), plus `cache_loggers?` and `clear_logger_cache`.
- When enabled, a **Class or Module** returns a single shared `Logger` per class, keyed on the class object (via a `Concurrent::Map`). Changing `level`/`filter` on that shared logger is now visible to every holder.
- **Strings always return a new instance**, even when caching is on. String call sites commonly want an independent logger (e.g. a different level per call site).
- **Anonymous classes** (no `name`) are never cached, to avoid pinning short-lived dynamically created classes in memory.
- Setting `cache_loggers = false` clears the cache; `clear_logger_cache` clears it explicitly (e.g. after redefining a class).
- With caching enabled, `SemanticLogger[MyClass]` and the `Loggable` mixin's `MyClass.logger` return the same instance.

## Design notes

- `tagged` is safe to share: it `clone`s and returns a child, never mutating the base instance. Only `level=`/`filter=`/`name=` mutate shared state, which is why this is opt-in.
- The global `Processor` (queue, appenders, thread, fork lifecycle) is already shared, so caching loggers introduces no new lifecycle interaction.
- Deliberately did **not** add String-to-constant resolution: `const_get` on the hot path is slow, can raise/autoload, and would silently merge call sites that used a string to stay independent.

This is public-surface v5 work; coordinating with the v4-pinned `rails_semantic_logger` is part of the existing v5 follow-up bump (it does not touch `[]` directly).

## Testing

- New `describe ".[]"` covering strings-always-fresh, class sharing, anonymous-not-cached, shared level changes, cache clearing, disable-clears, and Loggable consistency.
- Full suite: 1406 tests, 0 failures (10 MongoDB skips, no server). Rubocop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)