### PR TITLE
Document v5.0 changes in changelog and upgrading guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,22 +3,72 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [unreleased]
+## [5.0.0 unreleased]
 
+### Breaking changes
+
+See the [v5.0 upgrading guide](https://logger.rocketjob.io/upgrading.html) for migration details.
+
+- Ruby 3.2 is now the minimum supported runtime. Earlier versions are end-of-life and are no
+  longer tested.
 - Consolidate the asynchronous appender proxies: the worker thread and queue now live in an
   internal `SemanticLogger::QueueProcessor`, and `SemanticLogger::Appender::AsyncBatch` has been
   removed. `batch: true` now returns a `SemanticLogger::Appender::Async` (with `#batch?` true).
-  See the v5.0 upgrading guide.
+- Appenders are now reopened automatically in the child process after `fork` (and `Process.daemon`).
+  A `Process._fork` hook calls `SemanticLogger.reopen` for you, so most applications no longer need
+  an `after_fork`/`after_worker_boot` hook. Disable with `SemanticLogger.reopen_on_fork = false`.
+  Resolves #338.
+- Rename `SemanticLogger::Formatters::Base#cleanse` to `#escape_control_characters`. Custom
+  formatters or subclasses that called the old method name must be updated.
+- Syslog records now escape control characters by default to prevent log injection. Resolves #190.
+
+### New features
+
+- Add opt-in logger caching: `SemanticLogger.cache_loggers = true` makes `SemanticLogger[Class]`
+  (and the `Loggable` mixin) return a single shared `Logger` instance per class, so a later
+  `level=`/filter change is visible to every holder of that logger. Disabled by default; strings
+  and anonymous classes are never cached. Use `SemanticLogger.clear_logger_cache` to discard the
+  cache.
+- Add per-logger (child logger) tags: calling `logger.tagged(...)` (or `with_tags`) without a
+  block now returns a new logger instance that permanently carries the supplied positional and/or
+  named tags, scoped to that logger only. Resolves #165. Combines the approaches from #301 (theocodes)
+  and #321 (Fire-Dragon-DoL).
+- Add a configuration-driven Pattern formatter (`:pattern`) that renders log layouts from a
+  format string of directives. Resolves #78.
+- Add an ECS (Elastic Common Schema) formatter (`:ecs`). Resolves #295.
+- Add an OpenSearch appender (`appender: :opensearch`), sharing an Elasticsearch base. Resolves #189.
+- Add batch support to the HTTP appender (`batch: true`), posting an array of log events per
+  request. Resolves #278.
+- Allow separate stdout and stderr console appenders so warnings and errors can be routed to
+  stderr independently. Resolves #203.
+- Add non-blocking (drop) mode for async appenders: `non_blocking: true` drops messages instead of
+  blocking the calling thread once a capped queue is full, reporting dropped counts at most once
+  every `dropped_message_report_seconds` (default `30`).
 - Add retry-with-backoff for the asynchronous worker thread. When an appender raises while
   processing messages, the thread restarts with an increasing back-off and stops after
   `async_max_retries` (default `100`) consecutive failures instead of retrying forever. The
   counter resets after any message is processed successfully. Set `async_max_retries: -1` to
   restore the previous behaviour of retrying indefinitely.
-- Add per-logger (child logger) tags: calling `logger.tagged(...)` (or `with_tags`) without a
-  block now returns a new logger instance that permanently carries the supplied positional and/or
-  named tags, scoped to that logger only. Resolves #165. Combines the approaches from #301 (theocodes)
-  and #321 (Fire-Dragon-DoL).
-- Add upgrading guide to docs site covering v4.0 through v4.18, replace README upgrade sections with a link to the new page.
+- Add `SemanticLogger.stats` for operational metrics about the async queues (processed/dropped
+  counts, queue depth). Distinct from application metrics. Resolves #164.
+- Add an opt-in `escape_control_characters` option to the text formatters (default, color) to
+  escape control characters in formatted output.
+- Add a `permissions:` option to the file appender to restrict log file permissions on creation
+  and on existing files.
+
+### Fixes
+
+- Enforce UTF-8 encoding on JSON (and JSON-based) output to avoid `Encoding::UndefinedConversionError`
+  on invalid byte sequences. Resolves #180.
+- Fix the Fluentd formatter so `process_info` (pid, thread name) is excluded correctly. Resolves #190.
+- Fix `ArgumentError` in `CaptureLogEvents#batch`. Resolves #327.
+- Harden constant resolution and payload assignment against untrusted input.
+
+### Documentation
+
+- Add a Security documentation page.
+- Add upgrading guide to docs site covering v4.0 through v5.0, replace README upgrade sections with
+  a link to the new page.
 
 ## [4.18.0]
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -6,6 +6,14 @@ layout: default
 
 ### Upgrading to Semantic Logger v5.0
 
+#### Minimum Ruby version is now 3.2
+
+Semantic Logger v5 requires Ruby 3.2 or later. Earlier Ruby versions are end-of-life and are no
+longer supported or tested.
+
+If you are on an older Ruby, upgrade Ruby before upgrading Semantic Logger, or stay on the v4.x
+series.
+
 #### `SemanticLogger::Appender::AsyncBatch` has been removed
 
 The internal asynchronous proxy classes have been consolidated. Batch processing now runs through
@@ -29,6 +37,68 @@ What changed:
 If you have a custom appender or test asserting on the proxy class, change
 `instance_of?`/`is_a?(SemanticLogger::Appender::AsyncBatch)` checks to
 `SemanticLogger::Appender::Async` and, if needed, check `appender.batch?`.
+
+#### Appenders are reopened automatically after fork
+
+Previously, applications that fork (Puma, Unicorn, Spring, Resque, `Process.daemon`, etc.) had to
+call `SemanticLogger.reopen` themselves in an after-fork hook, otherwise the child shared the
+parent's file handles and background thread.
+
+In v5 this happens automatically: a `Process._fork` / `Process.daemon` hook calls
+`SemanticLogger.reopen` in the child process. The call is guarded to run once per process.
+
+For most applications you can now **remove** the manual reopen hook, for example:
+
+~~~ruby
+# No longer needed in v5 — handled automatically:
+before_fork { SemanticLogger.flush }
+after_fork  { SemanticLogger.reopen }
+~~~
+
+If you have a reason to manage this yourself (for example you reopen at a very specific point in
+your boot sequence), disable the automatic behaviour:
+
+~~~ruby
+SemanticLogger.reopen_on_fork = false
+~~~
+
+#### Recommended: enable logger caching
+
+By default `SemanticLogger[SomeClass]` returns a **new** `Logger` instance on every call. This means
+that if one part of the code obtains a logger and later changes its `level` (or filter), other
+holders of "the same" logger do not see the change, because they hold different instances.
+
+v5 adds opt-in caching so that a `Class` or `Module` maps to a single shared `Logger` instance:
+
+~~~ruby
+SemanticLogger.cache_loggers = true
+~~~
+
+With caching enabled:
+
+- `SemanticLogger[MyClass]` and the `Loggable` mixin's `MyClass.logger` return the **same** instance.
+- Changing that logger's level or filter is visible to every holder.
+- Strings (`SemanticLogger["Name"]`) always get a fresh instance, and anonymous classes (no `name`)
+  are never cached.
+
+Enabling caching is recommended for most applications. It is opt-in (default `false`) to preserve
+existing behaviour for code that relied on getting an independent logger per call. If you need to
+discard cached loggers (for example in tests, or after redefining a class), call
+`SemanticLogger.clear_logger_cache`.
+
+#### Control characters are escaped in Syslog output
+
+To prevent log-injection via embedded control characters (newlines, escape sequences, etc.), the
+Syslog formatter now escapes control characters in records by default. If you relied on raw control
+characters reaching syslog, this output now differs. The text formatters (default, color) also gain
+an opt-in `escape_control_characters` option (default `false`) for the same protection. See the
+[Security](security.html) page for details.
+
+#### `Formatters::Base#cleanse` renamed
+
+The internal `SemanticLogger::Formatters::Base#cleanse` method was renamed to
+`#escape_control_characters`. This only affects custom formatters or subclasses that called the old
+method name directly; update them to call `#escape_control_characters`.
 
 ### Upgrading to Semantic Logger v4.18
 


### PR DESCRIPTION
## Summary

Prepares the v5.0.0 release documentation.

- **CHANGELOG.md**: filled in the `[5.0.0 unreleased]` section with every public-facing change since `v4.18.0`, grouped into Breaking changes / New features / Fixes / Documentation. Internal-only commits (RuboCop autofixes, SimpleCov, minitest 6, test-coverage and dev-container changes) are intentionally omitted.
- **docs/upgrading.md**: expanded the v5.0 upgrading guide with the backward-compatibility items:
  - Minimum Ruby 3.2
  - Automatic reopen-on-fork (manual `after_fork { reopen }` hooks can be removed; opt out with `reopen_on_fork = false`)
  - Recommended `cache_loggers` opt-in, with the string/anonymous-class caveats and `clear_logger_cache`
  - Syslog control-character escaping change
  - `Formatters::Base#cleanse` → `#escape_control_characters` rename

JRuby is left unmentioned so it stays supported; it will be re-added to the tested matrix once the latest JRuby no longer crashes the test suite.

## Documentation coverage

Verified all public-facing v5 features already have doc updates (api.md, customize.md, appenders.md, index.md, forking.md, README). The only public change without a dedicated doc is the UTF-8 JSON enforcement (#180), an internal robustness fix with no API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)