### PR TITLE
Support zero-arity blocks and lambdas in log methods (#361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ See the [v5.0 upgrading guide](https://logger.rocketjob.io/upgrading.html) for m
   on invalid byte sequences. Resolves #180.
 - Fix the Fluentd formatter so `process_info` (pid, thread name) is excluded correctly. Resolves #190.
 - Fix `ArgumentError` in `CaptureLogEvents#batch`. Resolves #327.
+- Support zero-arity blocks and lambdas in the log methods, so `logger.info(&-> { "msg" })` no
+  longer raises `ArgumentError`. Blocks that accept an argument still receive the `Log`. Resolves #361.
 - Harden constant resolution and payload assignment against untrusted input.
 
 ### Documentation

--- a/lib/semantic_logger/base.rb
+++ b/lib/semantic_logger/base.rb
@@ -396,7 +396,7 @@ module SemanticLogger
     end
 
     # Log message at the specified level
-    def log_internal(level, index, message = nil, payload = nil, exception = nil)
+    def log_internal(level, index, message = nil, payload = nil, exception = nil, &block)
       # Handle variable number of arguments by detecting exception object and payload hash.
       if exception.nil? && payload.nil? && message.respond_to?(:backtrace) && message.respond_to?(:message)
         exception = message
@@ -423,18 +423,26 @@ module SemanticLogger
         end
 
       # Add result of block to message or payload if not nil
-      if block_given?
-        result = yield(log)
-        case result
-        when String
-          log.message = log.message.nil? ? result : "#{log.message} -- #{result}"
-        when Hash
-          log.assign_hash(result)
-        end
-      end
+      apply_block_result(log, &block) if block
 
       # Log level may change during assign due to :on_exception_level
       self.log(log) if should_log && should_log?(log)
+    end
+
+    # Merge the result of a logging block into the log entry.
+    #
+    # Zero-arity blocks (e.g. `logger.info { "msg" }` or a zero-arity lambda) are called without
+    # arguments. Lambdas enforce their arity, so yielding the log to a zero-arity lambda would
+    # raise ArgumentError. Blocks that accept an argument still receive the log so they can read
+    # or mutate it.
+    def apply_block_result(log, &block)
+      result = block.arity.zero? ? block.call : block.call(log)
+      case result
+      when String
+        log.message = log.message.nil? ? result : "#{log.message} -- #{result}"
+      when Hash
+        log.assign_hash(result)
+      end
     end
 
     # Measure the supplied block and log the message

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -168,6 +168,23 @@ module SemanticLogger
           assert_equal "Hello", last_log.message
           assert_equal({user: "joe"}, last_log.payload)
         end
+
+        it "supports a zero-arity lambda" do
+          logger.info(&-> { "From lambda" })
+
+          assert_equal "From lambda", last_log.message
+        end
+
+        it "passes the log to a block that accepts an argument" do
+          yielded = nil
+          logger.info("Hello") do |log|
+            yielded = log
+            nil
+          end
+
+          assert_instance_of SemanticLogger::Log, yielded
+          assert_equal "Hello", yielded.message
+        end
       end
 
       describe "#measure_<level>" do


### PR DESCRIPTION
## Summary

Fixes #361. `logger.info(&zero_arity_lambda)` raised `ArgumentError: wrong number of arguments (given 1, expected 0)`.

`log_internal` unconditionally yielded the `Log` object to the block. Plain blocks/procs ignore extra arguments, but **lambdas enforce their arity**, so a zero-arity lambda (such as those emitted by gems like `cequel` via `Rails.logger.debug(&-> { "msg" })`) blew up.

The fix dispatches on the block's arity:

```ruby
result = block.arity.zero? ? block.call : block.call(log)
```

- Zero-arity blocks/lambdas (`logger.info { "msg" }`, `logger.info(&-> { "msg" })`) are now called with **no arguments**.
- Blocks that accept an argument still receive the `Log` so they can read or mutate it (unchanged behavior).

The handling was extracted into a small `apply_block_result` helper, which also keeps `log_internal` under the rubocop complexity threshold.

`measure_internal` is intentionally untouched: its block is the work being measured (a different contract) and is not affected by this issue.

## Tests

Added two cases under the existing "block forms" group in `test/base_test.rb`:
- a zero-arity lambda is logged (the issue's repro),
- an arity-1 block still receives the `Log` object.

## Verification

- New + existing block-form tests pass
- `base_test` / `logger_test` pass
- Full suite green (1408 tests, 0 failures; only MongoDB tests skipped)
- `rubocop` clean

Backward-compatible; applies to the v4 line as well as v5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)