### PR TITLE
docs: update repo links from master to main

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -438,9 +438,9 @@ SemanticLogger.add_appender(file_name: "development.log", formatter: NoPidFormat
 ~~~
 
 See
-[SemanticLogger::Formatters::Default](https://github.com/reidmorrison/semantic_logger/blob/master/lib/semantic_logger/formatters/default.rb)
+[SemanticLogger::Formatters::Default](https://github.com/reidmorrison/semantic_logger/blob/main/lib/semantic_logger/formatters/default.rb)
 and
-[SemanticLogger::Formatters::Color](https://github.com/reidmorrison/semantic_logger/blob/master/lib/semantic_logger/formatters/color.rb)
+[SemanticLogger::Formatters::Color](https://github.com/reidmorrison/semantic_logger/blob/main/lib/semantic_logger/formatters/color.rb)
 for all the methods that can be overridden.
 
 To replace the formatter on an appender that is already installed, for example in a Rails app:
@@ -544,10 +544,10 @@ SemanticLogger.add_appender(appender: SimpleAppender.new)
 ~~~
 
 Look at the
-[existing appenders](https://github.com/reidmorrison/semantic_logger/tree/master/lib/semantic_logger/appender)
+[existing appenders](https://github.com/reidmorrison/semantic_logger/tree/main/lib/semantic_logger/appender)
 for good examples. To have a custom appender included in the standard list, submit it with complete
 working tests; see the
-[Graylog Appender Test](https://github.com/reidmorrison/semantic_logger/blob/master/test/appender/graylog_test.rb)
+[Graylog Appender Test](https://github.com/reidmorrison/semantic_logger/blob/main/test/appender/graylog_test.rb)
 for an example.
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -192,4 +192,4 @@ Configuration guide.
 ### Ruby Support
 
 For the complete list of supported Ruby versions, see
-the [Testing file](https://github.com/reidmorrison/semantic_logger/blob/master/.github/workflows/ci.yml).
+the [Testing file](https://github.com/reidmorrison/semantic_logger/blob/main/.github/workflows/ci.yml).

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -33,7 +33,7 @@ of log destinations see [Appenders](appenders.html).
 
 Rails Semantic Logger v5 requires **Ruby 3.2 or later** and **Rails 7.2 or later**. For the exact
 list of tested Ruby and Rails versions, see the
-[CI workflow](https://github.com/reidmorrison/rails_semantic_logger/blob/master/.github/workflows/ci.yml).
+[CI workflow](https://github.com/reidmorrison/rails_semantic_logger/blob/main/.github/workflows/ci.yml).
 
 ### Installation
 
@@ -292,7 +292,7 @@ config.rails_semantic_logger.appenders do |appenders|
 end
 ~~~
 
-See [SemanticLogger::Formatters::Color](https://github.com/reidmorrison/semantic_logger/blob/master/lib/semantic_logger/formatters/color.rb)
+See [SemanticLogger::Formatters::Color](https://github.com/reidmorrison/semantic_logger/blob/main/lib/semantic_logger/formatters/color.rb)
 for the methods you can override, and [Custom formatters](config.html#custom-formatters) for more on formatters.
 
 #### Amazing Print options for the color formatter

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -144,7 +144,7 @@ assert_semantic_logger_event(
 ~~~
 
 For more examples, see the
-[Rails Semantic Logger tests](https://github.com/reidmorrison/rails_semantic_logger/blob/master/test/active_record_test.rb).
+[Rails Semantic Logger tests](https://github.com/reidmorrison/rails_semantic_logger/blob/main/test/active_record_test.rb).
 
 ## RSpec
 


### PR DESCRIPTION
The default branch was renamed from `master` to `main`. This updates the in-repo documentation links that pointed at `reidmorrison/semantic_logger` and `reidmorrison/rails_semantic_logger` on the `master` branch to use `main`. Third-party links (net_tcp_client, newrelic) are left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)