### PR TITLE
docs: update project tagline to emphasize structured + asynchronous logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Semantic Logger
 [![Gem Version](https://img.shields.io/gem/v/semantic_logger.svg)](https://rubygems.org/gems/semantic_logger) [![Build Status](https://github.com/reidmorrison/semantic_logger/workflows/build/badge.svg)](https://github.com/reidmorrison/semantic_logger/actions?query=workflow%3Abuild) [![Downloads](https://img.shields.io/gem/dt/semantic_logger.svg)](https://rubygems.org/gems/semantic_logger) [![License](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)](http://opensource.org/licenses/Apache-2.0) ![](https://img.shields.io/badge/status-Production%20Ready-blue.svg)
 
-Semantic Logger is a feature rich logging framework, and a replacement for the existing
-Ruby and Rails loggers.
+Semantic Logger is a high-performance, asynchronous structured logging framework for Ruby
+and Rails.
 
 It differs from ordinary loggers in two important ways:
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="description"
-    content="Semantic Logger is a feature rich logging framework, and replacement for existing Ruby or Rails loggers. Supports Syslog, Graylog, Elasticsearch, Splunk, Loggly, New Relic, Bugsnag, MongoDB, HTTP(S).">
+    content="Semantic Logger is a high-performance, asynchronous structured logging framework for Ruby & Rails. Supports Syslog, Graylog, Elasticsearch, Splunk, Loggly, New Relic, Bugsnag, MongoDB, HTTP(S).">
   <title>Semantic Logger for Ruby or Rails. Supports Graylog, Bugsnag, MongoDB, Splunk, Syslog, NewRelic.</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" href="images/favicon.ico">
@@ -34,8 +34,8 @@
         <a href="{{ pair[0] }}" class="btn{% if pair[0] == current_page %} active{% endif %}">{{ pair[1] }}</a>{% endfor %}
         <a href="https://github.com/reidmorrison/semantic_logger" class="btn">GitHub</a>
         <h1 class="project-name">Semantic Logger</h1>
-        <h2 class="project-tagline">Semantic Logger is a feature rich logging framework, and replacement for existing
-          Ruby & Rails loggers.</h2>
+        <h2 class="project-tagline">Semantic Logger is a high-performance, asynchronous structured logging framework
+          for Ruby & Rails.</h2>
       </td>
       </tr>
     </table>

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,8 @@ layout: default
 * TOC
 {:toc}
 
-Semantic Logger is a feature rich logging framework for Ruby, and a replacement
-for the built-in Ruby and Rails loggers.
+Semantic Logger is a high-performance, asynchronous structured logging framework
+for Ruby and Rails.
 
 It does two things that ordinary loggers do not:
 

--- a/semantic_logger.gemspec
+++ b/semantic_logger.gemspec
@@ -11,9 +11,9 @@ Gem::Specification.new do |s|
   s.platform              = Gem::Platform::RUBY
   s.authors               = ["Reid Morrison"]
   s.homepage              = "https://logger.rocketjob.io"
-  s.summary               = "Feature rich logging framework, and replacement for existing Ruby & Rails loggers."
-  s.description           = "Semantic Logger is a feature rich logging framework, and replacement for existing Ruby & Rails loggers. " \
-                            "It logs to multiple destinations asynchronously via a background thread, with structured (semantic) payloads."
+  s.summary               = "High-performance, asynchronous structured logging framework for Ruby & Rails."
+  s.description           = "Semantic Logger is a high-performance, asynchronous structured logging framework for Ruby & Rails. " \
+                            "It logs to multiple destinations via a background thread, preserving structured (semantic) payloads."
   s.files                 = Dir["lib/**/*", "LICENSE.txt", "Rakefile", "README.md"]
   s.license               = "Apache-2.0"
   s.required_ruby_version = ">= 3.2"


### PR DESCRIPTION
## Summary

Replaces the long-standing "feature rich logging framework, and replacement for existing Ruby & Rails loggers" tagline with one that names the gem's actual differentiators:

> Semantic Logger is a high-performance, asynchronous structured logging framework for Ruby & Rails.

"Feature rich" was vague marketing language; "structured logging" and "asynchronous" are precise terms of art that describe what the gem does (and the latter is its defining trait), while also improving discoverability for people searching "structured logging ruby."

## Changes

- `semantic_logger.gemspec` — `summary` and `description` (reworded the description's second sentence to drop the now-redundant "asynchronously")
- `README.md` — opening tagline
- `docs/index.md` — opening tagline
- `docs/_layouts/default.html` — `<meta name="description">` (appender list retained) and the project tagline `<h2>`

The word "replacement" is dropped from the one-liner, but both the README and docs homepage immediately follow with the sections explaining how it differs from / replaces ordinary loggers, so that framing is preserved in the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)