### PR TITLE
Add RSpec test support mirroring the Minitest helpers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,7 @@ Layout/SpaceInsideHashLiteralBraces:
 Metrics/BlockLength:
   Exclude:
     - "test/**/*"
+    - "spec/**/*"
     - "**/*/cli.rb"
 
 # Soften limits
@@ -48,6 +49,7 @@ Metrics/ClassLength:
   Max: 250
   Exclude:
     - "test/**/*"
+    - "spec/**/*"
     # Large abstract base class shared by Logger and Subscriber.
     - "lib/semantic_logger/base.rb"
 
@@ -64,7 +66,7 @@ Metrics/ParameterLists:
 
 # Initialization Vector abbreviation
 Naming/MethodParameterName:
-  AllowedNames: ['iv', '_', 'io', 'ap']
+  AllowedNames: ['iv', '_', 'io', 'ap', 'on']
 
 # Does not allow Symbols to load
 Security/YAMLLoad:

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "minitest-reporters"
 gem "minitest-shared_description"
 gem "minitest-stub_any_instance"
 gem "rake"
+gem "rspec"
 gem "simplecov", require: false
 gem "solargraph", require: false, platform: :ruby
 

--- a/Rakefile
+++ b/Rakefile
@@ -21,4 +21,11 @@ Rake::TestTask.new(:test) do |t|
   t.warning = false
 end
 
-task default: :test
+begin
+  require "rspec/core/rake_task"
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+  # RSpec is only available in the test/development environment.
+end
+
+task default: %i[test spec]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -18,7 +18,7 @@ log events in memory** during a block, so you can make assertions on them.
 The events are captured as raw `SemanticLogger::Log` objects, before any appender or formatter runs,
 so your assertions are not affected by how logging happens to be configured.
 
-The fastest path is the Minitest helpers below. RSpec and other frameworks are covered further down.
+Helpers are provided for both Minitest and RSpec. Other frameworks are covered further down.
 
 ## Minitest
 
@@ -148,24 +148,109 @@ For more examples, see the
 
 ## RSpec
 
-There is no RSpec port of the Minitest helpers yet (pull requests welcome). In the meantime, capture
-events with `SemanticLogger::Test::CaptureLogEvents` and stub it in as the logger:
+The RSpec helpers mirror the Minitest ones: a capture helper plus matchers for asserting on the
+captured events.
+
+### Step 1: install the helpers
+
+Require the helpers and include them, once, in `spec_helper.rb`:
 
 ~~~ruby
-context "when it blows up" do
-  let(:capture_logger) { SemanticLogger::Test::CaptureLogEvents.new }
+require "semantic_logger/test/rspec"
 
-  it "logs the error" do
-    allow_any_instance_of(MyThing).to receive(:logger).and_return(capture_logger)
-    MyThing.new("asdf").do_something!
+RSpec.configure do |config|
+  config.include SemanticLogger::Test::RSpec
+end
+~~~
 
-    expect(capture_logger.events.last.message).to include("Here is a message")
-    expect(capture_logger.events.last.level).to eq(:error)
+### Step 2: capture events
+
+Wrap the code under test in `capture_semantic_logger_events`. It returns every log event created
+during the block, regardless of the global default log level:
+
+~~~ruby
+events = capture_semantic_logger_events do
+  User.new.enable!
+end
+~~~
+
+By default it captures events from every class. To capture only the events from one class, pass that
+class:
+
+~~~ruby
+events = capture_semantic_logger_events(ApiClient) do
+  # Only ApiClient log events created during this block are captured.
+end
+~~~
+
+### Step 3: assert on the events
+
+Use `be_a_semantic_logger_event` to assert on a single captured event:
+
+~~~ruby
+RSpec.describe User do
+  it "logs message" do
+    events = capture_semantic_logger_events do
+      User.new.enable!
+    end
+
+    expect(events.count).to eq(2)
+
+    expect(events[0]).to be_a_semantic_logger_event(
+      level:   :info,
+      message: "User enabled"
+    )
+
+    expect(events[1]).to be_a_semantic_logger_event(
+      level:   :debug,
+      message: "Completed"
+    )
   end
 end
 ~~~
 
-(Sample courtesy of @jgascoignetaylor-godaddy.)
+Every argument is optional, so you assert only on what matters to the test. The available checks are
+the same as the [Minitest table above](#step-3-assert-on-the-events), plus `message_includes`,
+`payload_includes`, and `exception_includes` for partial matches:
+
+~~~ruby
+expect(events[0]).to be_a_semantic_logger_event(
+  level:            :info,
+  message_includes: "enabled",
+  payload_includes: {first_name: "Jack"}
+)
+~~~
+
+An expected value that is a Class matches by type, and `:nil` asserts the attribute is `nil`:
+
+~~~ruby
+expect(events[0]).to be_a_semantic_logger_event(time: Time, exception: :nil)
+~~~
+
+### Match against a list of events
+
+`a_semantic_logger_event` is a composable alias, so it works inside `include` and other matchers:
+
+~~~ruby
+expect(events).to include(
+  a_semantic_logger_event(message: "User enabled")
+)
+~~~
+
+### Assert directly on a block
+
+`log_semantic_logger_event` captures the events for you and passes if any of them match. Pass `on:`
+to capture only one class's events:
+
+~~~ruby
+expect { User.new.enable! }.to(
+  log_semantic_logger_event(level: :info, message: "User enabled")
+)
+
+expect { ApiClient.new.call }.to(
+  log_semantic_logger_event(on: ApiClient, metric: "ApiClient/call")
+)
+~~~
 
 ## Other test frameworks
 

--- a/lib/semantic_logger/semantic_logger.rb
+++ b/lib/semantic_logger/semantic_logger.rb
@@ -622,6 +622,7 @@ module SemanticLogger
   module Test
     autoload :CaptureLogEvents,  "semantic_logger/test/capture_log_events"
     autoload :Minitest,          "semantic_logger/test/minitest"
+    autoload :RSpec,             "semantic_logger/test/rspec"
   end
 
   if defined?(JRuby)

--- a/lib/semantic_logger/test/minitest.rb
+++ b/lib/semantic_logger/test/minitest.rb
@@ -58,16 +58,16 @@ module SemanticLogger
           payload_includes.each_pair do |key, expected|
             actual = event.payload[key]
 
-            assert_semantic_logger_entry(event, "payload #{name}", expected, actual)
+            assert_semantic_logger_entry(event, "payload #{key}", expected, actual)
           end
         end
 
         return unless exception_includes
 
-        payload_includes.each_pair do |key, expected|
+        exception_includes.each_pair do |key, expected|
           actual = event.exception.send(key)
 
-          assert_semantic_logger_entry(event, "Exception #{name}", expected, actual)
+          assert_semantic_logger_entry(event, "exception #{key}", expected, actual)
         end
       end
 

--- a/lib/semantic_logger/test/rspec.rb
+++ b/lib/semantic_logger/test/rspec.rb
@@ -1,0 +1,249 @@
+require "rspec/expectations"
+
+module SemanticLogger
+  module Test
+    # RSpec matchers and helpers for asserting on Semantic Logger events.
+    #
+    # These mirror the Minitest helpers in SemanticLogger::Test::Minitest.
+    #
+    # Enable them once, in spec_helper.rb:
+    #
+    #   require "semantic_logger/test/rspec"
+    #
+    #   RSpec.configure do |config|
+    #     config.include SemanticLogger::Test::RSpec
+    #   end
+    #
+    # Capture the events emitted whilst running a block, then assert on them:
+    #
+    #   events = capture_semantic_logger_events { User.new.enable! }
+    #   expect(events.first).to be_a_semantic_logger_event(level: :info, message: "User enabled")
+    #
+    # Or assert directly that a block logs a matching event:
+    #
+    #   expect { User.new.enable! }.to(
+    #     log_semantic_logger_event(level: :info, message: "User enabled")
+    #   )
+    module RSpec
+      # Attributes that may be asserted on a single log event. The keys map
+      # directly onto SemanticLogger::Log attributes, except for the
+      # *_includes variants which assert a partial (substring / subset) match.
+      EVENT_ATTRIBUTES = %i[
+        level name message thread_name tags named_tags context
+        metric metric_amount dimensions level_index duration time
+        exception backtrace payload
+      ].freeze
+
+      # Matches a single SemanticLogger::Log against a set of expectations.
+      #
+      # An expected value may be:
+      #   * a Class    - the actual value must be a kind_of that class
+      #   * :nil       - the actual value must be nil
+      #   * any value  - compared with ==
+      class EventMatcher
+        include ::RSpec::Matchers::Composable
+
+        def initialize(message_includes: nil, payload_includes: nil, exception_includes: nil, **expected)
+          unknown = expected.keys - EVENT_ATTRIBUTES
+          raise ArgumentError, "Unknown log event attribute(s): #{unknown.join(', ')}" unless unknown.empty?
+
+          @expected           = expected
+          @message_includes   = message_includes
+          @payload_includes   = payload_includes
+          @exception_includes = exception_includes
+        end
+
+        def matches?(event)
+          @event = event
+          return failed("no log event") unless event
+
+          @expected.each_pair do |name, expected|
+            actual = event.public_send(name)
+            return failed(mismatch(name, expected, actual)) unless attribute_matches?(expected, actual)
+          end
+
+          return failed(includes_failure(:message, @message_includes)) unless message_includes_matches?
+          return failed(includes_failure(:payload, @payload_includes)) unless payload_includes_matches?
+          return failed(includes_failure(:exception, @exception_includes)) unless exception_includes_matches?
+
+          true
+        end
+
+        def description
+          "be a semantic logger event matching #{full_expectations.inspect}"
+        end
+
+        def failure_message
+          "expected log event to #{description}, but #{@failure}.\n" \
+            "Log event: #{event_inspect}"
+        end
+
+        def failure_message_when_negated
+          "expected log event not to #{description}.\nLog event: #{event_inspect}"
+        end
+
+        private
+
+        def failed(reason)
+          @failure = reason
+          false
+        end
+
+        def attribute_matches?(expected, actual)
+          case expected
+          when :nil
+            actual.nil?
+          when Class
+            actual.is_a?(expected)
+          else
+            expected == actual
+          end
+        end
+
+        def message_includes_matches?
+          return true unless @message_includes
+
+          @event.message&.include?(@message_includes)
+        end
+
+        def payload_includes_matches?
+          return true unless @payload_includes
+
+          payload = @event.payload || {}
+          @payload_includes.all? { |key, value| payload[key] == value }
+        end
+
+        def exception_includes_matches?
+          return true unless @exception_includes
+
+          exception = @event.exception
+          return false unless exception
+
+          @exception_includes.all? { |key, value| exception.public_send(key) == value }
+        end
+
+        def mismatch(name, expected, actual)
+          "#{name} was #{actual.inspect} (expected #{expected.inspect})"
+        end
+
+        def includes_failure(name, expected)
+          "#{name} did not include #{expected.inspect}"
+        end
+
+        def full_expectations
+          @expected.merge(
+            {
+              message_includes:   @message_includes,
+              payload_includes:   @payload_includes,
+              exception_includes: @exception_includes
+            }.compact
+          )
+        end
+
+        def event_inspect
+          @event.respond_to?(:to_h) ? @event.to_h.inspect : @event.inspect
+        end
+      end
+
+      # Matches a block, asserting that it emits at least one log event that
+      # matches the supplied expectations.
+      class LogEventMatcher
+        include ::RSpec::Matchers::Composable
+
+        def initialize(capture, on:, expected:)
+          @capture  = capture
+          @on       = on
+          @matcher  = EventMatcher.new(**expected)
+        end
+
+        def matches?(block)
+          @events = @capture.call(@on, &block)
+          @events.any? { |event| @matcher.matches?(event) }
+        end
+
+        def supports_block_expectations?
+          true
+        end
+
+        def description
+          "log a semantic logger event matching #{@matcher.description}"
+        end
+
+        def failure_message
+          "expected the block to #{description}.\n" \
+            "Captured #{@events.size} event(s):\n#{captured_inspect}"
+        end
+
+        def failure_message_when_negated
+          "expected the block not to #{description}, but it did.\n" \
+            "Captured #{@events.size} event(s):\n#{captured_inspect}"
+        end
+
+        private
+
+        def captured_inspect
+          @events.map { |event| "  #{event.to_h.inspect}" }.join("\n")
+        end
+      end
+
+      # Returns [Array<SemanticLogger::Log>] the log events captured whilst
+      # running the supplied block.
+      #
+      # Notes:
+      # - All log events are captured regardless of the global default log level.
+      # - Pass a class to capture only events logged through that class's logger.
+      #   Otherwise every log event in the process is captured for the duration
+      #   of the block.
+      def capture_semantic_logger_events(klass = nil, silence: :trace, &block)
+        logger = SemanticLogger::Test::CaptureLogEvents.new
+
+        if klass
+          allow(klass).to receive(:logger).and_return(logger)
+          block.call
+        elsif silence
+          SemanticLogger.silence(silence) do
+            stub_processor(logger, &block)
+          end
+        else
+          stub_processor(logger, &block)
+        end
+
+        logger.events
+      end
+
+      # Matcher for a single captured log event.
+      #
+      #   expect(events.first).to be_a_semantic_logger_event(level: :info, message: "Hi")
+      def be_a_semantic_logger_event(**expected)
+        EventMatcher.new(**expected)
+      end
+
+      # Composable alias, for use inside other matchers:
+      #
+      #   expect(events).to include(a_semantic_logger_event(message: "Hi"))
+      def a_semantic_logger_event(**expected)
+        EventMatcher.new(**expected)
+      end
+
+      # Block matcher asserting that the block logs a matching event.
+      #
+      #   expect { User.new.enable! }.to(
+      #     log_semantic_logger_event(level: :info, message: "User enabled")
+      #   )
+      #
+      # Pass `on:` to capture only one class's events.
+      def log_semantic_logger_event(on: nil, **expected)
+        LogEventMatcher.new(method(:capture_semantic_logger_events), on: on, expected: expected)
+      end
+
+      private
+
+      def stub_processor(logger)
+        allow(SemanticLogger::Logger).to receive(:processor).and_return(logger)
+        yield
+      ensure
+        allow(SemanticLogger::Logger).to receive(:processor).and_call_original
+      end
+    end
+  end
+end

--- a/spec/semantic_logger/test/rspec_spec.rb
+++ b/spec/semantic_logger/test/rspec_spec.rb
@@ -1,0 +1,155 @@
+require_relative "../../spec_helper"
+
+# Sample application class that emits log events.
+class RSpecMatcherUser
+  include SemanticLogger::Loggable
+
+  def enable!
+    logger.info("User enabled", first_name: "Jack", last_name: "Jones", metric: "User/enabled")
+  end
+
+  def disable!
+    logger.info(metric: "User/disabled")
+  end
+
+  def fail!
+    logger.error("Boom", StandardError.new("kaboom"))
+  end
+end
+
+RSpec.describe SemanticLogger::Test::RSpec do
+  let(:user) { RSpecMatcherUser.new }
+
+  describe "#capture_semantic_logger_events" do
+    it "captures every event by default" do
+      events = capture_semantic_logger_events { user.enable! }
+
+      expect(events.map(&:message)).to eq(["User enabled"])
+    end
+
+    it "captures only the supplied class's events" do
+      events = capture_semantic_logger_events(RSpecMatcherUser) { user.enable! }
+
+      expect(events.size).to eq(1)
+      expect(events.first.message).to eq("User enabled")
+    end
+
+    it "captures events below the global default level" do
+      SemanticLogger.default_level = :error
+
+      events = capture_semantic_logger_events { user.enable! }
+
+      expect(events.first.level).to eq(:info)
+    ensure
+      SemanticLogger.default_level = :trace
+    end
+
+    it "restores the original processor afterwards" do
+      capture_semantic_logger_events { user.enable! }
+
+      expect(SemanticLogger::Logger.processor).not_to be_a(SemanticLogger::Test::CaptureLogEvents)
+    end
+  end
+
+  describe "be_a_semantic_logger_event" do
+    let(:event) { capture_semantic_logger_events { user.enable! }.first }
+
+    it "matches on level and exact message" do
+      expect(event).to be_a_semantic_logger_event(level: :info, message: "User enabled")
+    end
+
+    it "matches a partial message" do
+      expect(event).to be_a_semantic_logger_event(message_includes: "enabled")
+    end
+
+    it "matches an exact payload" do
+      expect(event).to be_a_semantic_logger_event(
+        payload: {first_name: "Jack", last_name: "Jones"}
+      )
+    end
+
+    it "matches a partial payload" do
+      expect(event).to be_a_semantic_logger_event(payload_includes: {first_name: "Jack"})
+    end
+
+    it "matches a metric" do
+      expect(event).to be_a_semantic_logger_event(metric: "User/enabled")
+    end
+
+    it "matches a Class expectation against the value's type" do
+      expect(event).to be_a_semantic_logger_event(time: Time)
+    end
+
+    it "matches a :nil expectation against a nil value" do
+      expect(event).to be_a_semantic_logger_event(exception: :nil)
+    end
+
+    it "does not match when an attribute differs" do
+      expect(event).not_to be_a_semantic_logger_event(level: :error)
+    end
+
+    it "does not match when a partial message is absent" do
+      expect(event).not_to be_a_semantic_logger_event(message_includes: "disabled")
+    end
+
+    it "raises when given an unknown attribute" do
+      expect { be_a_semantic_logger_event(bogus: 1) }.to raise_error(ArgumentError, /bogus/)
+    end
+
+    it "produces a helpful failure message" do
+      matcher = be_a_semantic_logger_event(level: :error)
+      matcher.matches?(event)
+
+      expect(matcher.failure_message).to include("level was :info")
+    end
+
+    context "with an exception" do
+      let(:event) { capture_semantic_logger_events { user.fail! }.first }
+
+      it "matches partial exception attributes" do
+        expect(event).to be_a_semantic_logger_event(
+          level:              :error,
+          exception_includes: {message: "kaboom"}
+        )
+      end
+
+      it "matches the exception class" do
+        expect(event).to be_a_semantic_logger_event(exception: StandardError)
+      end
+    end
+  end
+
+  describe "a_semantic_logger_event" do
+    it "composes inside other matchers" do
+      events = capture_semantic_logger_events { user.enable! }
+
+      expect(events).to include(a_semantic_logger_event(message: "User enabled"))
+    end
+  end
+
+  describe "log_semantic_logger_event" do
+    it "matches when the block logs a matching event" do
+      expect { user.enable! }.to(
+        log_semantic_logger_event(level: :info, message: "User enabled")
+      )
+    end
+
+    it "scopes capture to a class with on:" do
+      expect { user.enable! }.to(
+        log_semantic_logger_event(on: RSpecMatcherUser, metric: "User/enabled")
+      )
+    end
+
+    it "does not match when no event matches" do
+      expect { user.enable! }.not_to(
+        log_semantic_logger_event(message: "Something else")
+      )
+    end
+
+    it "matches a metric only event" do
+      expect { user.disable! }.to(
+        log_semantic_logger_event(metric: "User/disabled")
+      )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+require "semantic_logger"
+require "semantic_logger/test/rspec"
+
+# Run logging synchronously so events are captured on the calling thread.
+SemanticLogger.sync!
+SemanticLogger.default_level = :trace
+
+RSpec.configure do |config|
+  config.include SemanticLogger::Test::RSpec
+
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+end

--- a/test/test/minitest_test.rb
+++ b/test/test/minitest_test.rb
@@ -1,0 +1,107 @@
+require_relative "../test_helper"
+
+# Tests for the SemanticLogger::Test::Minitest helpers themselves:
+# semantic_logger_events (capture) and assert_semantic_logger_event (assertion).
+class MinitestHelpersTest < Minitest::Test
+  class User
+    include SemanticLogger::Loggable
+
+    def enable!
+      logger.info("User enabled", first_name: "Jack", last_name: "Jones", metric: "User/enabled")
+    end
+
+    def disable!
+      logger.info(metric: "User/disabled")
+    end
+
+    def fail!
+      logger.error("Boom", StandardError.new("kaboom"))
+    end
+  end
+
+  describe "semantic_logger_events" do
+    it "captures every event by default" do
+      events = semantic_logger_events { User.new.enable! }
+
+      assert_equal ["User enabled"], events.map(&:message)
+    end
+
+    it "captures only the supplied class's events" do
+      events = semantic_logger_events(User) { User.new.enable! }
+
+      assert_equal 1, events.size
+      assert_equal "User enabled", events.first.message
+    end
+
+    it "captures events below the global default level" do
+      original_level = SemanticLogger.default_level
+      SemanticLogger.default_level = :error
+      begin
+        events = semantic_logger_events { User.new.enable! }
+
+        assert_equal :info, events.first.level
+      ensure
+        SemanticLogger.default_level = original_level
+      end
+    end
+  end
+
+  describe "assert_semantic_logger_event" do
+    let(:event) { semantic_logger_events { User.new.enable! }.first }
+    let(:error_event) { semantic_logger_events { User.new.fail! }.first }
+
+    it "matches on level and exact message" do
+      assert_semantic_logger_event(event, level: :info, message: "User enabled")
+    end
+
+    it "matches a partial message" do
+      assert_semantic_logger_event(event, message_includes: "enabled")
+    end
+
+    it "matches an exact payload" do
+      assert_semantic_logger_event(event, payload: {first_name: "Jack", last_name: "Jones"})
+    end
+
+    it "matches a partial payload" do
+      assert_semantic_logger_event(event, payload_includes: {first_name: "Jack"})
+    end
+
+    it "matches a metric" do
+      assert_semantic_logger_event(event, metric: "User/enabled")
+    end
+
+    it "matches a Class expectation against the value's type" do
+      assert_semantic_logger_event(event, time: Time)
+    end
+
+    it "matches a :nil expectation against a nil value" do
+      assert_semantic_logger_event(event, exception: :nil)
+    end
+
+    it "matches partial exception attributes" do
+      assert_semantic_logger_event(error_event, level: :error, exception_includes: {message: "kaboom"})
+    end
+
+    it "matches the exception class" do
+      assert_semantic_logger_event(error_event, exception: StandardError)
+    end
+
+    it "fails when there is no event" do
+      assert_raises(Minitest::Assertion) do
+        assert_semantic_logger_event(nil, message: "anything")
+      end
+    end
+
+    it "fails when an attribute differs" do
+      assert_raises(Minitest::Assertion) do
+        assert_semantic_logger_event(event, level: :error)
+      end
+    end
+
+    it "fails when a partial message is absent" do
+      assert_raises(Minitest::Assertion) do
+        assert_semantic_logger_event(event, message_includes: "disabled")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #371.

Semantic Logger shipped Minitest helpers (`SemanticLogger::Test::Minitest`) but only a "no port yet, PRs welcome" placeholder for RSpec. This adds a first-class RSpec port, built on the existing `CaptureLogEvents`, so RSpec users get the same ergonomics.

## `SemanticLogger::Test::RSpec`

Enable once in `spec_helper.rb`:

```ruby
require "semantic_logger/test/rspec"

RSpec.configure do |config|
  config.include SemanticLogger::Test::RSpec
end
```

It provides:

- **`capture_semantic_logger_events(klass = nil, silence:) { }`** — block capture helper, the RSpec parallel to Minitest's `semantic_logger_events`. Captures every event (or just one class's) regardless of the global default level.
- **`be_a_semantic_logger_event(**attrs)`** — single-event matcher with the same attribute set as `assert_semantic_logger_event`, plus `message_includes` / `payload_includes` / `exception_includes` partial matches, and `Class` (type) and `:nil` expectation semantics, with helpful failure messages.
- **`a_semantic_logger_event(**attrs)`** — composable alias for use inside `include(...)`.
- **`log_semantic_logger_event(on:, **attrs)`** — block matcher that captures and asserts in one step.

```ruby
events = capture_semantic_logger_events { User.new.enable! }
expect(events.first).to be_a_semantic_logger_event(level: :info, message: "User enabled")
expect(events).to include(a_semantic_logger_event(payload_includes: {first_name: "Jack"}))

expect { User.new.enable! }.to log_semantic_logger_event(on: User, metric: "User/enabled")
```

## Also in this PR

- Added `rspec` as a dev dependency, a `:spec` rake task wired into the default task, and matching `spec/` rubocop excludes.
- Added specs for the new matchers, and Minitest tests for the previously-untested `semantic_logger_events` / `assert_semantic_logger_event`.
- **Bug fix:** the Minitest helper's `exception_includes` branch iterated `payload_includes`, which crashed with `NoMethodError` on nil when `exception_includes` was passed without `payload_includes`.
- Documented the RSpec helpers in `docs/testing.md`.

## Sister gem

`rails_semantic_logger` is now also at the v5 level, so these helpers can be wired in there as part of the coordinated v5 release if desired.

## Verification

- `bundle exec rake` → 1423 Minitest tests + 22 RSpec examples, 0 failures (Mongo tests skipped without `MONGO_HOST`).
- `bundle exec rubocop` → clean on all changed/new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)