### PR TITLE
docs: add earlier-version upgrade notes to Rails guide

### DIFF
--- a/docs/rails.md
+++ b/docs/rails.md
@@ -346,6 +346,27 @@ Because the block disables the automatic appenders, this JSON-to-stdout appender
 destination: there is no default file log and no separate color logger under `rails server`, which
 is exactly what a container platform wants.
 
+To keep one configuration that works both locally and in-cluster, gate the JSON appender on an
+environment variable that is only set in the container platform. For example, in
+`config/application.rb` (so it applies to every environment), switch to JSON on standard out only
+when running inside Kubernetes:
+
+~~~ruby
+# config/application.rb
+config.semantic_logger.application = "my_application"
+config.semantic_logger.environment = ENV["STACK_NAME"] || Rails.env
+config.log_level = ENV["LOG_LEVEL"] || :info
+
+if ENV["LOG_TO_CONSOLE"] || ENV["KUBERNETES_SERVICE_HOST"]
+  config.rails_semantic_logger.appenders do |appenders|
+    appenders.add(io: $stdout, formatter: :json)
+  end
+end
+~~~
+
+Outside the cluster the block is skipped, so the default `log/<env>.log` file and the usual screen
+loggers apply; inside the cluster JSON to stdout becomes the only destination.
+
 On Heroku, also allow the log level to be set from the environment:
 
 ~~~ruby

--- a/docs/rails.md
+++ b/docs/rails.md
@@ -693,6 +693,39 @@ stay silent. If you do not use the appenders block at all, the v4 behavior is pr
 
 ---
 
+## Migrating from earlier versions
+
+These notes apply to upgrades between older releases and are retained for reference.
+
+### v4.16: Sidekiq metrics support
+
+Rails Semantic Logger added support for Sidekiq metrics, available when the JSON logging format is
+used:
+
+* `sidekiq.job.perform` &mdash; the duration of each Sidekiq job; `duration` contains the time in
+  milliseconds that the job took to run.
+* `sidekiq.queue.latency` &mdash; the time between when a Sidekiq job was enqueued and when it was
+  started; `metric_amount` contains the time in milliseconds that the job was waiting in the queue.
+
+### v4.15 and v4.16: Sidekiq support
+
+Rails Semantic Logger introduced direct support for Sidekiq v4, v5, v6, and v7. Remove any previous
+custom patches or configurations used to make Sidekiq work with Semantic Logger. To see the complete
+list of patches and to contribute your own, see
+[Sidekiq Patches](https://github.com/reidmorrison/rails_semantic_logger/blob/main/lib/rails_semantic_logger/extensions/sidekiq/sidekiq.rb).
+
+### v4.4
+
+With some forking frameworks it was necessary to call `reopen` after the fork. As of v4.4 the
+workaround for Ruby 2.5 crashes is no longer needed. Remove the following line if it is called
+anywhere:
+
+~~~ruby
+SemanticLogger::Processor.instance.instance_variable_set(:@queue, Queue.new)
+~~~
+
+---
+
 ## Deprecated configuration options
 
 The following options still function in v5 for backward compatibility but emit deprecation warnings


### PR DESCRIPTION
## Summary

Consolidates the upgrade notes that previously lived in the `rails_semantic_logger` README into the Rails docs. Adds a **Migrating from earlier versions** section to `docs/rails.md` (after "Migrating from v4 to v5") covering:

- **v4.16** Sidekiq metrics support (`sidekiq.job.perform`, `sidekiq.queue.latency`)
- **v4.15 / v4.16** Sidekiq support (remove custom patches)
- **v4.4** reopen-after-fork / Ruby 2.5 workaround removal

This is the docs companion to reidmorrison/rails_semantic_logger#315, which trims the README and links here for upgrade guidance (the new `#migrating-from-earlier-versions` anchor).

## Test plan

- Docs-only change; rendered headings produce the `migrating-from-earlier-versions` anchor referenced from the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)