### PR TITLE
Open the file appender's log file eagerly so add_appender fails fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- The file appender opens its log file when it is created, so a misconfigured path or
+  insufficient permissions now raise immediately from `SemanticLogger.add_appender`,
+  instead of surfacing later on the appender thread via the internal logger while log
+  messages are lost. This restores the pre-4.9 behavior and matches the other appenders,
+  which already open their resources eagerly. As a result the log file is created as soon
+  as the appender is added, even if nothing is logged (the same as the standard Ruby and
+  Rails loggers).
+
 ## [5.0.0] 2026-06-29
 
 ### Breaking changes

--- a/docs/appenders.md
+++ b/docs/appenders.md
@@ -143,6 +143,9 @@ SemanticLogger.add_appender(file_name: "development.log", formatter: :color)
 SemanticLogger.add_appender(file_name: "development.log", formatter: :json)
 ~~~
 
+The file is opened when the appender is added, so a bad path or insufficient permissions raise
+immediately from `add_appender` instead of failing later on the logging thread.
+
 For performance the log file is not re-opened on every call, so rotate it with a copy-truncate
 operation rather than deleting the file. See [Log rotation](operations.html#log-rotation).
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1421,6 +1421,9 @@ SemanticLogger.add_appender(file_name: "development.log", formatter: :color)
 SemanticLogger.add_appender(file_name: "development.log", formatter: :json)
 ~~~
 
+The file is opened when the appender is added, so a bad path or insufficient permissions raise
+immediately from `add_appender` instead of failing later on the logging thread.
+
 For performance the log file is not re-opened on every call, so rotate it with a copy-truncate
 operation rather than deleting the file. See [Log rotation](operations.html#log-rotation).
 

--- a/lib/semantic_logger/appender/file.rb
+++ b/lib/semantic_logger/appender/file.rb
@@ -150,6 +150,11 @@ module SemanticLogger
         @reopen_at      = nil
 
         super(**args, &)
+
+        # Open the file at creation time so that misconfiguration (bad directory,
+        # insufficient permissions, ...) raises immediately in SemanticLogger.add_appender,
+        # instead of surfacing later on the appender thread via the internal logger.
+        reopen
       end
 
       # After forking an active process call #reopen to re-open

--- a/semantic_logger.gemspec
+++ b/semantic_logger.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "concurrent-ruby", "~> 1.0"
   s.metadata = {
     "bug_tracker_uri"       => "https://github.com/reidmorrison/semantic_logger/issues",
-    "changelog_uri"         => "https://github.com/reidmorrison/semantic_logger/releases",
+    "changelog_uri"         => "https://github.com/reidmorrison/semantic_logger/blob/main/CHANGELOG.md",
     "documentation_uri"     => "https://logger.rocketjob.io",
     "source_code_uri"       => "https://github.com/reidmorrison/semantic_logger/tree/v#{SemanticLogger::VERSION}",
     "rubygems_mfa_required" => "true"

--- a/test/appender/file_test.rb
+++ b/test/appender/file_test.rb
@@ -20,6 +20,26 @@ module Appender
         FileUtils.rm_f(file_name)
       end
 
+      describe "#initialize" do
+        it "opens the file on creation" do
+          appender
+
+          assert_path_exists file_name
+        end
+
+        it "raises immediately when the file cannot be opened" do
+          assert_raises Errno::ENOENT do
+            SemanticLogger::Appender::File.new("no_such_directory/test.log")
+          end
+        end
+
+        it "raises immediately when the file name is a directory" do
+          assert_raises ArgumentError do
+            SemanticLogger::Appender::File.new(__dir__)
+          end
+        end
+      end
+
       describe "#log" do
         it "logs output" do
           assert appender.log(log)
@@ -137,8 +157,8 @@ module Appender
       end
 
       describe "#flush" do
-        it "flushes output" do
-          refute appender.flush
+        it "flushes the file opened on creation" do
+          assert appender.flush
         end
 
         it "flushes output after logging" do
@@ -149,8 +169,8 @@ module Appender
       end
 
       describe "#time_to_reopen?" do
-        it "before anything is logged" do
-          assert appender.send(:time_to_reopen?)
+        it "not before anything is logged since the file is opened on creation" do
+          refute appender.send(:time_to_reopen?)
         end
 
         describe "reopen_count" do
@@ -195,15 +215,23 @@ module Appender
         describe "reopen_period" do
           let(:appender) { SemanticLogger::Appender::File.new(file_name, reopen_period: "1m") }
 
+          it "sets the reopen time when the file is opened on creation" do
+            refute_nil appender.reopen_at
+          end
+
           it "opens a new log file at the beginning of the next minute" do
-            assert_nil appender.reopen_at
+            # Construct the appender before stubbing Time.now: nested stubs of the
+            # same method break minitest's stub restore.
+            appender
 
             Time.stub(:now, current_time) do
+              appender.reopen
+
+              assert_equal Time.parse("2015-12-09 17:51:00"), appender.reopen_at
               appender.info("Hello world how are you doing")
 
               refute appender.send(:time_to_reopen?)
             end
-            assert_equal Time.parse("2015-12-09 17:51:00"), appender.reopen_at
             assert appender.send(:time_to_reopen?)
 
             assert_file_reopened(appender) do

--- a/test/appenders_test.rb
+++ b/test/appenders_test.rb
@@ -32,6 +32,10 @@ class AppendersTest < Minitest::Test
     let(:appenders) { SemanticLogger::Appenders.new(capture_logger) }
     let(:logger) { SemanticLogger::Test::CaptureLogEvents.new }
 
+    after do
+      FileUtils.rm_f("sample.log")
+    end
+
     describe "#add" do
       it "adds file appender" do
         appender = appenders.add(file_name: "sample.log")


### PR DESCRIPTION
## Summary

`SemanticLogger.add_appender(file_name: ...)` succeeded silently even when the path was misconfigured (nonexistent directory, insufficient permissions, or a directory passed as the file name). The file appender deferred opening the file to the first log call, so the failure surfaced later on the appender thread as repeated `Failed to log to appender` errors on the internal `$stderr` logger, while every message to that appender was silently lost.

This PR opens the file in `initialize`, so the error raises immediately from `add_appender` on the caller's thread:

- Restores the pre-4.9 behavior (the lazy open arrived with the file-name format directives and rotation work in `07ad81f`, whose fork rationale is obsolete now that v5 automatically reopens appenders after `fork`).
- Matches every other resource-owning appender (Http, Tcp, Udp, Kafka, Rabbitmq, MongoDB, Syslog, Graylog, Splunk, CloudwatchLogs, Elasticsearch), which already open eagerly in `initialize`.
- Visible side effect: the log file is created as soon as the appender is added, even if nothing is logged, the same as the standard Ruby and Rails loggers. Format directives and rotation are unaffected since they are recomputed on every reopen.

Also includes an unrelated one-line gemspec change pointing `changelog_uri` at `CHANGELOG.md` instead of GitHub releases.

Note: `rails_semantic_logger` carries workarounds for this exact issue (`RailsSemanticLogger.eager_open` and an explicit `appender.reopen` in its engine). They remain harmless since `reopen` is idempotent, and will be reverted there separately.

## Testing

- New tests assert the file is created at construction and that a bad path (`Errno::ENOENT`) or a directory (`ArgumentError`) raises immediately.
- Updated the three tests that relied on the lazy open (`#flush` before logging, `time_to_reopen?` before logging, and `reopen_period`, whose `reopen_at` is now set at creation).
- Full suite passes in both async and `LOGGER_SYNC=1` modes; rubocop clean.
- Verified end to end in a scratch script: bad path raises from `add_appender`, valid path creates the file before any logging, and logging still writes through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)