### PR TITLE
Point doc site references at the new domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ enabled (for example `ruby -W:deprecated`, or Rails development mode).
 
 ### Breaking changes
 
-See the [v5.0 upgrading guide](https://logger.rocketjob.io/upgrading.html) for migration details.
+See the [v5.0 upgrading guide](https://logger.reidmorrison.com/upgrading.html) for migration details.
 
 - Ruby 3.2 is now the minimum supported runtime. Earlier versions are end-of-life and are no
   longer tested.
@@ -586,13 +586,13 @@ logger.info message: 'Hello', metric: 'user/hello', duration: 25
     - Deprecated non hash style arguments.
     - For Example:
         - `SemanticLogger.add_appender(file_name: 'development.log', formatter: :color)`
-    - See [Appenders](https://logger.rocketjob.io/appenders.html)
+    - See [Appenders](https://logger.reidmorrison.com/appenders.html)
     - Move AnsiColors into its own module: `SemanticLogger::AnsiColors`
 - Appenders now use the same hash style arguments as `SemanticLogger.add_appender`.
 - Appenders use the new common formatters where applicable.
 - Appenders now use custom formatters as the `#call` method for better performance over blocks.
 - Bugsnag appender will now forward `:fatal` errors, since some were being ignored and
-  not being reported in Bugsnag. Changes in [Rails Semantic Logger](https://logger.rocketjob.io/rails.html)
+  not being reported in Bugsnag. Changes in [Rails Semantic Logger](https://logger.reidmorrison.com/rails.html)
   allow Rails messages to be sent correctly to Bugsnag.
 - Use Ruby's built-in JSON library
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ To add a new appender or formatter, add the class under the respective directory
 
 ## Docs
 
-User-facing documentation is a Jekyll site under [docs/](docs/) (published to logger.rocketjob.io). When changing public behavior, update the relevant `docs/*.md` page (e.g. `appenders.md`, `metrics.md`, `api.md`, `testing.md`).
+User-facing documentation is a Jekyll site under [docs/](docs/) (published to logger.reidmorrison.com). When changing public behavior, update the relevant `docs/*.md` page (e.g. `appenders.md`, `metrics.md`, `api.md`, `testing.md`).
 
 The site also serves two files for AI assistants: [docs/llms.txt](docs/llms.txt), a hand-maintained index of the docs pages (update it when adding or renaming a page), and `docs/llms-full.txt`, all pages concatenated, regenerated with `bundle exec rake llms_full`. **After editing any `docs/*.md` page, re-run `bundle exec rake llms_full`** and commit the result; never edit `llms-full.txt` by hand. The `docs/*.md` sources also ship inside the gem package (see `s.files` in the gemspec) so coding agents inside applications can read them locally.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ how the project grows, and they are warmly welcomed and appreciated.
 
 Documentation updates are welcome and appreciated by all users of Semantic Logger.
 
-The documentation is a Jekyll site under the `docs` subdirectory, published to [logger.rocketjob.io](https://logger.rocketjob.io).
+The documentation is a Jekyll site under the `docs` subdirectory, published to [logger.reidmorrison.com](https://logger.reidmorrison.com).
 
 #### Small changes
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ replaces the Rails default logger with Semantic Logger automatically.
 
 ## Documentation
 
-Start with the [Introduction](https://logger.rocketjob.io/), then the
-[Programmer's Guide](https://logger.rocketjob.io/api.html).
+Start with the [Introduction](https://logger.reidmorrison.com/), then the
+[Programmer's Guide](https://logger.reidmorrison.com/api.html).
 
-* Full guide: [https://logger.rocketjob.io/](https://logger.rocketjob.io/)
-* For AI assistants: [llms.txt](https://logger.rocketjob.io/llms.txt) (documentation index) and
-  [llms-full.txt](https://logger.rocketjob.io/llms-full.txt) (complete documentation in one file).
+* Full guide: [https://logger.reidmorrison.com/](https://logger.reidmorrison.com/)
+* For AI assistants: [llms.txt](https://logger.reidmorrison.com/llms.txt) (documentation index) and
+  [llms-full.txt](https://logger.reidmorrison.com/llms-full.txt) (complete documentation in one file).
   The same pages are also included as markdown in the installed gem, under `docs/`.
 
 ## Logging Destinations
@@ -82,7 +82,7 @@ instead of Semantic Logger directly since it will automatically replace the Rail
 
 ## Rocket Job
 
-Checkout the sister project [Rocket Job](http://rocketjob.io): Ruby's missing batch system.
+Checkout the sister project [Rocket Job](https://rocketjob.reidmorrison.com): Ruby's missing batch system.
 
 Fully supports Semantic Logger when running jobs in the background. Complete support for job metrics
 sent via Semantic Logger to your favorite dashboards.
@@ -109,7 +109,7 @@ and are therefore not automatically included by this gem:
 
 ## Upgrading
 
-See the [Upgrading Guide](https://logger.rocketjob.io/upgrading.html) for instructions on
+See the [Upgrading Guide](https://logger.reidmorrison.com/upgrading.html) for instructions on
 upgrading between major versions.
 
 ## Install
@@ -128,7 +128,7 @@ SemanticLogger.default_level = :trace
 SemanticLogger.add_appender(file_name: 'development.log', formatter: :color)
 ~~~
 
-If running rails, see: [Semantic Logger Rails](https://logger.rocketjob.io/rails.html)
+If running rails, see: [Semantic Logger Rails](https://logger.reidmorrison.com/rails.html)
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -25,9 +25,9 @@ task :llms_full do
 
     > Semantic Logger is a high-performance, asynchronous structured logging framework for Ruby and Rails.
 
-    This file concatenates every page of https://logger.rocketjob.io for consumption by AI assistants.
+    This file concatenates every page of https://logger.reidmorrison.com for consumption by AI assistants.
     It is generated from the markdown sources in docs/ by `bundle exec rake llms_full`; do not edit it directly.
-    A per-page index is available at https://logger.rocketjob.io/llms.txt
+    A per-page index is available at https://logger.reidmorrison.com/llms.txt
   HEADER
 
   sections = pages.map do |page|

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -23,7 +23,7 @@
     <table style="width:100%">
       <td>
       <td>
-        <a href="http://rocketjob.io/">
+        <a href="https://rocketjob.reidmorrison.com/">
           <img src="images/header-rocket-256.png" alt="Rocket Job" class="header-image">
         </a>
       </td>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2,9 +2,9 @@
 
 > Semantic Logger is a high-performance, asynchronous structured logging framework for Ruby and Rails.
 
-This file concatenates every page of https://logger.rocketjob.io for consumption by AI assistants.
+This file concatenates every page of https://logger.reidmorrison.com for consumption by AI assistants.
 It is generated from the markdown sources in docs/ by `bundle exec rake llms_full`; do not edit it directly.
-A per-page index is available at https://logger.rocketjob.io/llms.txt
+A per-page index is available at https://logger.reidmorrison.com/llms.txt
 
 
 ---

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,8 +6,8 @@ Key facts:
 
 - Install with `gem install semantic_logger` or `gem "semantic_logger"` in a Gemfile. Requires Ruby 3.2 or later.
 - Rails applications should use the companion gem [rails_semantic_logger](https://github.com/reidmorrison/rails_semantic_logger), which replaces the Rails default logger automatically. Do not configure this gem directly in Rails.
-- Human-readable documentation lives at https://logger.rocketjob.io. The links below point at the raw markdown sources of the same pages.
-- The complete documentation concatenated into a single file: https://logger.rocketjob.io/llms-full.txt
+- Human-readable documentation lives at https://logger.reidmorrison.com. The links below point at the raw markdown sources of the same pages.
+- The complete documentation concatenated into a single file: https://logger.reidmorrison.com/llms-full.txt
 - Source code: https://github.com/reidmorrison/semantic_logger
 
 ## Documentation

--- a/semantic_logger.gemspec
+++ b/semantic_logger.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version               = SemanticLogger::VERSION
   s.platform              = Gem::Platform::RUBY
   s.authors               = ["Reid Morrison"]
-  s.homepage              = "https://logger.rocketjob.io"
+  s.homepage              = "https://logger.reidmorrison.com"
   s.summary               = "High-performance, asynchronous structured logging framework for Ruby & Rails."
   s.description           = "Semantic Logger is a high-performance, asynchronous structured " \
                             "logging framework for Ruby & Rails. It logs to multiple destinations " \
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.metadata = {
     "bug_tracker_uri"       => "https://github.com/reidmorrison/semantic_logger/issues",
     "changelog_uri"         => "https://github.com/reidmorrison/semantic_logger/blob/main/CHANGELOG.md",
-    "documentation_uri"     => "https://logger.rocketjob.io",
+    "documentation_uri"     => "https://logger.reidmorrison.com",
     "source_code_uri"       => "https://github.com/reidmorrison/semantic_logger/tree/v#{SemanticLogger::VERSION}",
     "rubygems_mfa_required" => "true"
   }


### PR DESCRIPTION
`docs/CNAME` already moved to `logger.reidmorrison.com`, but a few references still pointed at the old host:

- `docs/llms.txt` and `docs/llms-full.txt` advertised `logger.rocketjob.io`
- `docs/_layouts/default.html`: the Rocket Job header logo linked to `http://rocketjob.io/`, now `https://rocketjob.reidmorrison.com/` (confirmed it resolves to the same GitHub Pages target)

`docs/_site/` is gitignored build output and will regenerate on the next Jekyll build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)